### PR TITLE
a pass on all doc and doc-links with cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CLIPPY_ARGS = --all-targets --all-features -- -D clippy::wildcard_dependencies -D rust-2018-idioms -D warnings
 CRITERION_PLOTS_DIR = bench/target/criterion
+NIGHTLY := $(shell rustup show|grep nightly 2> /dev/null)
 
 .PHONY: bench build build-rel clean clean-plots docs fmt lint find-plots test watch watch-bench watch-test
 
@@ -19,7 +20,11 @@ clean-plots:
 	@rm -rf $(CRITERION_PLOTS_DIR)
 
 docs:
-	@cargo doc --lib --no-deps --all-features
+ifdef NIGHTLY
+	@RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p capsule --no-deps --all-features
+else
+	@cargo doc -p capsule --no-deps --all-features
+endif
 
 find-plots:
 	@ls $(CRITERION_PLOTS_DIR)/report/index.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![Apache-2.0 licensed][apache-badge]][apache-url]
+[![CI-Github Actions][gh-actions-badge]][gh-actions-url]
+[![Codecov][codecov-badge]][codecov-url]
+[![Code of Conduct][code-of-conduct-badge]][code-of-conduct-url]
+[![Discord][discord-badge]][discord-url]
+
+[crates-badge]: https://img.shields.io/crates/v/capsule.svg
+[crates-url]: https://crates.io/crates/capsule
+[docs-badge]: https://docs.rs/capsule/badge.svg?version=0.1.0
+[docs-url]: https://docs.rs/capsule/0.1.0/capsule
+[apache-badge]: https://img.shields.io/github/license/capsule-rs/capsule
+[apache-url]: LICENSE
+[gh-actions-badge]: https://github.com/capsule-rs/capsule/workflows/build/badge.svg
+[gh-actions-url]: https://github.com/capsule-rs/capsule/actions
+[codecov-badge]: https://codecov.io/gh/capsule-rs/capsule/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/capsule-rs/capsule
+[code-of-conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-ff69b4
+[code-of-conduct-url]: CODE_OF_CONDUCT.md
+[discord-badge]: https://img.shields.io/discord/690406128567320597.svg?logo=discord
+[discord-url]: https://discord.gg/sVN47RU
+
 # Capsule
 
 A framework for network function development. Written in Rust, inspired by [NetBricks](https://www.usenix.org/system/files/conference/osdi16/osdi16-panda.pdf) and built on Intel's [Data Plane Development Kit](https://www.dpdk.org/).

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "capsule-bench"
 version = "0.1.0"
-authors = ["Capsule Developers <occam_engineering@comcast.com>"]
+authors = ["Capsule Developers <capsule-dev@googlegroups.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "Benchmarks for Capsule"
-categories = []
+publish = false
+description = """
+Benchmarks for Capsule.
+"""
 
 [dev-dependencies]
 capsule = { path = "../core", features = ["testils"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
 name = "capsule"
 version = "0.1.0"
-authors = ["Capsule Developers <occam_engineering@comcast.com>"]
+authors = ["Capsule Developers <capsule-dev@googlegroups.com>"]
 license = "Apache-2.0"
-keywords = []
 edition = "2018"
-description = "A network function framework written in Rust and using DPDK"
-categories = []
+readme = "README.md"
+repository = "https://github.com/capsule/capsule"
+keywords = ["nfv", "network-functions", "packet-processing", "packet-parsing", "dpdk"]
+categories = ["network-programming", "development-tools::ffi"]
+documentation = "https://docs.rs/capsule/0.1.0/capsule/"
+description = """
+A framework for network function development. Written in Rust, inspired by
+NetBricks and built on Intel's Data Plane Development Kit.
+"""
 
 [lib]
 name = "capsule"
@@ -41,6 +47,11 @@ proptest = { version = "0.9", default-features = false, features = ["default-cod
 
 [features]
 default = ["metrics"]
+full = ["metrics", "pcap-dump", "testils"]
 metrics = ["metrics-core", "metrics-runtime"]
 pcap-dump = []
-testils = ["proptest", "criterion"]
+testils = ["criterion", "proptest"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/core/src/batch/emit.rs
+++ b/core/src/batch/emit.rs
@@ -19,13 +19,17 @@
 use super::{Batch, Disposition, PacketTx};
 use crate::packets::Packet;
 
-/// A batch that transmits the packets through the specified `PacketTx`.
+/// A batch that transmits the packets through the specified [`PacketTx`].
+///
+/// [`PacketTx`]: crate::batch::PacketTx
+#[allow(missing_debug_implementations)]
 pub struct Emit<B: Batch, Tx: PacketTx> {
     batch: B,
     tx: Tx,
 }
 
 impl<B: Batch, Tx: PacketTx> Emit<B, Tx> {
+    /// Creates a new `Emit` batch.
     #[inline]
     pub fn new(batch: B, tx: Tx) -> Self {
         Emit { batch, tx }

--- a/core/src/batch/filter.rs
+++ b/core/src/batch/filter.rs
@@ -23,6 +23,7 @@ use crate::packets::Packet;
 ///
 /// If the predicate evaluates to `false`, the packet is marked as dropped
 /// and will short-circuit the remainder of the pipeline.
+#[allow(missing_debug_implementations)]
 pub struct Filter<B: Batch, P>
 where
     P: FnMut(&B::Item) -> bool,
@@ -35,6 +36,7 @@ impl<B: Batch, P> Filter<B, P>
 where
     P: FnMut(&B::Item) -> bool,
 {
+    /// Creates a new `Filter` batch.
     #[inline]
     pub fn new(batch: B, predicate: P) -> Self {
         Filter { batch, predicate }

--- a/core/src/batch/filter_map.rs
+++ b/core/src/batch/filter_map.rs
@@ -20,7 +20,10 @@ use super::{Batch, Disposition};
 use crate::packets::Packet;
 use crate::{Mbuf, Result};
 
-/// The result of the filter map.
+/// The result of a [`filter_map`].
+///
+/// [`filter_map`]: crate::batch::Batch::filter_map
+#[allow(missing_debug_implementations)]
 pub enum Either<T> {
     /// Keeps the packet as mapped result.
     Keep(T),
@@ -34,6 +37,7 @@ pub enum Either<T> {
 /// If the closure returns `Drop`, the packet is marked as dropped. On
 /// error, the packet is marked as aborted. In both scenarios, it will
 /// short-circuit the remainder of the pipeline.
+#[allow(missing_debug_implementations)]
 pub struct FilterMap<B: Batch, T: Packet, F>
 where
     F: FnMut(B::Item) -> Result<Either<T>>,
@@ -46,6 +50,7 @@ impl<B: Batch, T: Packet, F> FilterMap<B, T, F>
 where
     F: FnMut(B::Item) -> Result<Either<T>>,
 {
+    /// Creates a new `FilterMap` batch.
     #[inline]
     pub fn new(batch: B, f: F) -> Self {
         FilterMap { batch, f }

--- a/core/src/batch/for_each.rs
+++ b/core/src/batch/for_each.rs
@@ -20,6 +20,7 @@ use super::{Batch, Disposition};
 use crate::Result;
 
 /// A batch that calls a closure on packets in the underlying batch.
+#[allow(missing_debug_implementations)]
 pub struct ForEach<B: Batch, F>
 where
     F: FnMut(&B::Item) -> Result<()>,
@@ -32,6 +33,7 @@ impl<B: Batch, F> ForEach<B, F>
 where
     F: FnMut(&B::Item) -> Result<()>,
 {
+    /// Creates a new `ForEach` batch.
     #[inline]
     pub fn new(batch: B, f: F) -> Self {
         ForEach { batch, f }

--- a/core/src/batch/group_by.rs
+++ b/core/src/batch/group_by.rs
@@ -24,17 +24,20 @@ use std::hash::Hash;
 use std::rc::Rc;
 
 /// A bridge between the main batch pipeline and the branch pipelines
-/// created by the `GroupBy` combinator. Packets can be fed one at a time
+/// created by the [`GroupBy`] combinator. Packets can be fed one at a time
 /// through the bridge. Because the pipeline execution is depth first,
 /// this is the most efficient way storage wise.
+#[allow(missing_debug_implementations)]
 #[derive(Clone, Default)]
 pub struct Bridge<T: Packet>(Rc<Cell<Option<T>>>);
 
 impl<T: Packet> Bridge<T> {
+    /// Creates a new, empty bridge.
     pub fn new() -> Self {
         Bridge(Rc::new(Cell::new(None)))
     }
 
+    /// Feeds a packet into the bridge container.
     pub fn set(&self, pkt: T) {
         self.0.set(Some(pkt));
     }
@@ -63,6 +66,7 @@ pub type GroupByBatchBuilder<T> = dyn FnOnce(Bridge<T>) -> Box<dyn Batch<Item = 
 ///
 /// All the sub batches must have the same packet type as the underlying
 /// batch.
+#[allow(missing_debug_implementations)]
 pub struct GroupBy<B: Batch, D, S>
 where
     D: Eq + Clone + Hash,
@@ -80,6 +84,7 @@ where
     D: Eq + Clone + Hash,
     S: Fn(&B::Item) -> D,
 {
+    /// Creates a new `GroupBy` batch.
     #[inline]
     pub fn new<C>(batch: B, selector: S, composer: C) -> Self
     where
@@ -156,7 +161,9 @@ macro_rules! __compose {
     }};
 }
 
-/// Composes the batch builders for the `group_by` combinator
+/// Composes the batch builders for the [`group_by`] combinator.
+///
+/// [`group_by`]: crate::batch::Batch::group_by
 #[macro_export]
 macro_rules! compose {
     ($map:ident { $($key:expr => |$arg:tt| $body:block)+ }) => {{

--- a/core/src/batch/inspect.rs
+++ b/core/src/batch/inspect.rs
@@ -18,7 +18,9 @@
 
 use super::{Batch, Disposition};
 
-/// A batch that calls a closure on packets in the underlying batch.
+/// A batch that calls a closure on packets in the underlying batch, including
+/// ones that are already dropped, emitted or aborted.
+#[allow(missing_debug_implementations)]
 pub struct Inspect<B: Batch, F>
 where
     F: FnMut(&Disposition<B::Item>),
@@ -31,6 +33,7 @@ impl<B: Batch, F> Inspect<B, F>
 where
     F: FnMut(&Disposition<B::Item>),
 {
+    /// Creates a new `Inspect` batch.
     #[inline]
     pub fn new(batch: B, f: F) -> Self {
         Inspect { batch, f }

--- a/core/src/batch/map.rs
+++ b/core/src/batch/map.rs
@@ -24,6 +24,7 @@ use crate::Result;
 ///
 /// On error, the packet is marked as `aborted` and will short-circuit the
 /// remainder of the pipeline.
+#[allow(missing_debug_implementations)]
 pub struct Map<B: Batch, T: Packet, F>
 where
     F: FnMut(B::Item) -> Result<T>,
@@ -36,6 +37,7 @@ impl<B: Batch, T: Packet, F> Map<B, T, F>
 where
     F: FnMut(B::Item) -> Result<T>,
 {
+    /// Creates a new `Map` batch.
     #[inline]
     pub fn new(batch: B, f: F) -> Self {
         Map { batch, f }

--- a/core/src/batch/poll.rs
+++ b/core/src/batch/poll.rs
@@ -23,6 +23,7 @@ use std::collections::VecDeque;
 /// A batch that polls a receiving source for new packets.
 ///
 /// This marks the beginning of the pipeline.
+#[allow(missing_debug_implementations)]
 pub struct Poll<Rx: PacketRx> {
     rx: Rx,
     packets: Option<VecDeque<Mbuf>>,

--- a/core/src/batch/replace.rs
+++ b/core/src/batch/replace.rs
@@ -25,6 +25,7 @@ use crate::Result;
 /// The original packet is dropped from the batch with the new packet in its
 /// place. On error, the packet is `aborted` and will short-circuit the
 /// remainder of the pipeline.
+#[allow(missing_debug_implementations)]
 pub struct Replace<B: Batch, T: Packet, F>
 where
     F: FnMut(&B::Item) -> Result<T>,
@@ -38,6 +39,7 @@ impl<B: Batch, T: Packet, F> Replace<B, T, F>
 where
     F: FnMut(&B::Item) -> Result<T>,
 {
+    /// Creates a new `Replace` batch.
     #[inline]
     pub fn new(batch: B, f: F) -> Self {
         Replace {

--- a/core/src/batch/rxtx.rs
+++ b/core/src/batch/rxtx.rs
@@ -70,6 +70,8 @@ impl PacketTx for Sender<Mbuf> {
     }
 }
 
+/// A batch that polls a closure for packets.
+#[allow(missing_debug_implementations)]
 pub struct PollRx<F>
 where
     F: Fn() -> Vec<Mbuf>,

--- a/core/src/batch/send.rs
+++ b/core/src/batch/send.rs
@@ -39,7 +39,8 @@ fn new_counter(name: &'static str, pipeline: &str) -> Counter {
     )
 }
 
-/// Turns the batch pipeline into an executable task.
+/// A batch that can be executed as a runtime task.
+#[allow(missing_debug_implementations)]
 pub struct Send<B: Batch, Tx: PacketTx> {
     name: String,
     batch: B,
@@ -55,12 +56,14 @@ pub struct Send<B: Batch, Tx: PacketTx> {
 }
 
 impl<B: Batch, Tx: PacketTx> Send<B, Tx> {
+    /// Creates a new `Send` batch.
     #[cfg(not(feature = "metrics"))]
     #[inline]
     pub fn new(name: String, batch: B, tx: Tx) -> Self {
         Send { name, batch, tx }
     }
 
+    /// Creates a new `Send` batch.
     #[cfg(feature = "metrics")]
     #[inline]
     pub fn new(name: String, batch: B, tx: Tx) -> Self {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -16,6 +16,35 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Toml-based configuration for use with Capsule applications.
+//!
+//! # Example
+//!
+//! A configuration from our [`pktdump`] example:
+//! ```
+//! app_name = "pktdump"
+//! master_core = 0
+//! duration = 5
+//!
+//! [mempool]
+//!     capacity = 65535
+//!     cache_size = 256
+//!
+//! [[ports]]
+//!     name = "eth1"
+//!     device = "net_pcap0"
+//!     args = "rx_pcap=tcp4.pcap,tx_iface=lo"
+//!     cores = [0]
+//!
+//! [[ports]]
+//!     name = "eth2"
+//!     device = "net_pcap1"
+//!     args = "rx_pcap=tcp6.pcap,tx_iface=lo"
+//!     cores = [0]
+//! ```
+//!
+//! [`pktdump`]: https://github.com/capsule-rs/capsule/tree/master/examples/pktdump
+
 use crate::dpdk::CoreId;
 use crate::net::{Ipv4Cidr, Ipv6Cidr, MacAddr};
 use crate::Result;
@@ -26,7 +55,6 @@ use std::fmt;
 use std::fs;
 use std::str::FromStr;
 use std::time::Duration;
-use toml;
 
 // make `CoreId` serde deserializable.
 impl<'de> Deserialize<'de> for CoreId {
@@ -103,7 +131,7 @@ where
     Ok(option)
 }
 
-/// Runtime config settings.
+/// Runtime configuration settings.
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RuntimeConfig {
@@ -145,10 +173,10 @@ pub struct RuntimeConfig {
     /// The ports to use for the application. Must have at least one.
     pub ports: Vec<PortConfig>,
 
-    /// Additional DPDK parameters to pass on for EAL initialization. When
+    /// Additional DPDK [`parameters`] to pass on for EAL initialization. When
     /// set, the values are passed through as is without validation.
     ///
-    /// See https://doc.dpdk.org/guides/linux_gsg/linux_eal_parameters.html.
+    /// [`parameters`]: https://doc.dpdk.org/guides/linux_gsg/linux_eal_parameters.html
     #[serde(default)]
     pub dpdk_args: Option<String>,
 
@@ -259,7 +287,7 @@ impl fmt::Debug for RuntimeConfig {
     }
 }
 
-/// Mempool config settings.
+/// Mempool configuration settings.
 #[derive(Clone, Deserialize)]
 pub struct MempoolConfig {
     /// The maximum number of Mbufs the mempool can allocate. The optimum
@@ -302,7 +330,7 @@ impl fmt::Debug for MempoolConfig {
     }
 }
 
-/// Port config settings.
+/// Port configuration settings.
 #[derive(Clone, Deserialize)]
 pub struct PortConfig {
     /// The application assigned logical name of the port.

--- a/core/src/dpdk/mbuf.rs
+++ b/core/src/dpdk/mbuf.rs
@@ -32,9 +32,11 @@ use std::slice;
 /// Size of the structs are used for bound checks when reading and writing
 /// packets.
 ///
-/// For convenience, use the `SizeOf` derive macro.
 ///
-/// # Example
+/// ## Derivable
+///
+/// The `SizeOf` trait can be used with `#[derive]` and defaults to
+/// `std::mem::size_of::<Self>()`.
 ///
 /// ```
 /// #[derive(SizeOf)]
@@ -79,7 +81,7 @@ impl SizeOf for ::std::net::Ipv6Addr {
 
 /// Error indicating buffer access failures.
 #[derive(Debug, Fail)]
-pub enum BufferError {
+pub(crate) enum BufferError {
     /// The offset exceeds the buffer length.
     #[fail(display = "Offset {} exceeds the buffer length {}.", _0, _1)]
     BadOffset(usize, usize),

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -23,18 +23,20 @@ mod port;
 #[cfg(feature = "metrics")]
 mod stats;
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::kni::*;
+#[allow(unreachable_pub)]
 pub use self::mbuf::*;
-pub use self::mempool::*;
+pub(crate) use self::mempool::*;
+#[allow(unreachable_pub)]
 pub use self::port::*;
 #[cfg(feature = "metrics")]
-pub use self::stats::*;
+pub(crate) use self::stats::*;
 
 use crate::ffi::{self, AsStr, ToCString, ToResult};
 use crate::net::MacAddr;
 use crate::{debug, Result};
 use failure::Fail;
-use libc;
 use std::cell::Cell;
 use std::fmt;
 use std::mem;
@@ -45,7 +47,7 @@ use std::os::raw;
 /// When a FFI call fails, the `errno` is translated into `DpdkError`.
 #[derive(Debug, Fail)]
 #[fail(display = "{}", _0)]
-pub struct DpdkError(String);
+pub(crate) struct DpdkError(String);
 
 impl DpdkError {
     /// Returns the `DpdkError` for the most recent failure on the current
@@ -172,7 +174,7 @@ thread_local! {
 }
 
 /// Initializes the Environment Abstraction Layer (EAL).
-pub fn eal_init(args: Vec<String>) -> Result<()> {
+pub(crate) fn eal_init(args: Vec<String>) -> Result<()> {
     debug!(arguments=?args);
 
     let len = args.len() as raw::c_int;
@@ -189,7 +191,7 @@ pub fn eal_init(args: Vec<String>) -> Result<()> {
 }
 
 /// Cleans up the Environment Abstraction Layer (EAL).
-pub fn eal_cleanup() -> Result<()> {
+pub(crate) fn eal_cleanup() -> Result<()> {
     unsafe { ffi::rte_eal_cleanup().to_result().map(|_| ()) }
 }
 

--- a/core/src/dpdk/stats.rs
+++ b/core/src/dpdk/stats.rs
@@ -23,14 +23,14 @@ use crate::Result;
 use std::ptr::NonNull;
 
 /// Port stats collector.
-pub struct PortStats {
+pub(crate) struct PortStats {
     id: PortId,
     name: String,
 }
 
 impl PortStats {
     /// Builds a collector from the port.
-    pub fn build(port: &Port) -> Self {
+    pub(crate) fn build(port: &Port) -> Self {
         PortStats {
             id: port.id(),
             name: port.name().to_owned(),
@@ -38,7 +38,7 @@ impl PortStats {
     }
 
     /// Returns the port name.
-    pub fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         self.name.as_str()
     }
 
@@ -57,7 +57,7 @@ impl PortStats {
     }
 
     /// Collects the port stats tracked by DPDK.
-    pub fn collect(&self) -> Result<Vec<(Key, Measurement)>> {
+    pub(crate) fn collect(&self) -> Result<Vec<(Key, Measurement)>> {
         let mut stats = ffi::rte_eth_stats::default();
         unsafe {
             ffi::rte_eth_stats_get(self.id.raw(), &mut stats).to_result()?;
@@ -77,13 +77,13 @@ impl PortStats {
 }
 
 /// Mempool stats collector.
-pub struct MempoolStats {
+pub(crate) struct MempoolStats {
     raw: NonNull<ffi::rte_mempool>,
 }
 
 impl MempoolStats {
     /// Builds a collector from the port.
-    pub fn build(mempool: &Mempool) -> Self {
+    pub(crate) fn build(mempool: &Mempool) -> Self {
         MempoolStats {
             raw: unsafe {
                 NonNull::new_unchecked(
@@ -116,7 +116,7 @@ impl MempoolStats {
     }
 
     /// Collects the mempool stats.
-    pub fn collect(&self) -> Vec<(Key, Measurement)> {
+    pub(crate) fn collect(&self) -> Vec<(Key, Measurement)> {
         let used = unsafe { ffi::rte_mempool_in_use_count(self.raw()) as i64 };
         let free = self.raw().size as i64 - used;
 

--- a/core/src/ffi.rs
+++ b/core/src/ffi.rs
@@ -16,7 +16,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-pub use capsule_ffi::*;
+pub(crate) use capsule_ffi::*;
 
 use crate::dpdk::DpdkError;
 use crate::{warn, Result};
@@ -25,7 +25,7 @@ use std::os::raw;
 use std::ptr::NonNull;
 
 /// Simplify `*const c_char` or [c_char] to `&str` conversion.
-pub trait AsStr {
+pub(crate) trait AsStr {
     fn as_str(&self) -> &str;
 }
 
@@ -54,7 +54,7 @@ impl AsStr for [raw::c_char] {
 }
 
 /// Simplify `String` and `&str` to `CString` conversion.
-pub trait ToCString {
+pub(crate) trait ToCString {
     fn to_cstring(self) -> CString;
 }
 
@@ -73,7 +73,7 @@ impl ToCString for &str {
 }
 
 /// Simplify FFI binding's return to `Result` conversion.
-pub trait ToResult {
+pub(crate) trait ToResult {
     type Ok;
 
     fn to_result(self) -> Result<Self::Ok>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,98 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+#![deny(intra_doc_link_resolution_failure)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(html_root_url = "https://docs.rs/capsule/0.1.0")]
+
+//! A framework for network function development. Written in Rust, inspired by
+//! [`NetBricks`] and built on Intel's [`Data Plane Development Kit`].
+//!
+//! The goal of Capsule is to offer an ergonomic framework for network function
+//! development that traditionally has high barriers of entry for developers.
+//! We've created a tool to efficiently manipulate network packets while being
+//! type-safe, memory-safe, and thread-safe. Building on DPDK and Rust, Capsule
+//! offers:
+//!
+//! * a fast packet processor that uses minimum number of CPU cycles.
+//! * a rich packet type system that guarantees memory-safety and thread-safety.
+//! * a declarative programming model that emphasizes simplicity.
+//! * an extensible and testable framework that is easy to develop and maintain.
+//!
+//! ## Getting started
+//!
+//! The easiest way to start developing Capsule applications is to use the
+//! `Vagrant` [`virtual machine`] and the `Docker` [`sandbox`] provided by the
+//! Capsule team. The sandbox is preconfigured with all the necessary tools and
+//! libraries for Capsule development, including:
+//!
+//! * [`DPDK 18.11`]
+//! * [`Clang`] and [`LLVM`]
+//! * [`Rust 1.42`]
+//! * [`rr`] 5.3
+//!
+//! For more information on getting started, please check out Capsule's
+//! [`README`], as well as our [`sandbox repo`] for developer environments.
+//!
+//! ### Adding Capsule as a Cargo dependency
+//!
+//! ```toml
+//! [dependencies]
+//! capsule = "0.1"
+//! ```
+//!
+//! To enable test/bench features for example, you can include Capsule in your
+//! Cargo dependencies with the `testils` feature flag:
+//!
+//! ```toml
+//! [dev-dependencies]
+//! capsule = { version = "0.1", features = ["testils"] }
+//! ```
+//!
+//! ## Feature flags
+//!
+//! - `default`: Enables metrics by default.
+//! - `metrics`: Enables automatic [`metrics`] collection.
+//! - `pcap-dump`: Enables capturing port traffic to (.pcap) files.
+//! - `testils`: Enables utilities for unit testing and benchmarking.
+//! - `full`: Enables all features.
+//!
+//! ### Examples
+//!
+//! - [`kni`]: Kernel NIC interface example.
+//! - [`nat64`]: IPv6 to IPv4 NAT gateway example.
+//! - [`ping4d`]: Ping4 daemon example.
+//! - [`pktdump`]: Packet dump example.
+//! - [`signals`]: Linux signal handling example.
+//! - [`skeleton`]: Base skeleton example.
+//! - [`syn-flood`]: TCP SYN flood example.
+//!
+//! [`NetBricks`]: https://www.usenix.org/system/files/conference/osdi16/osdi16-panda.pdf
+//! [`Data Plane Development Kit`]: https://www.dpdk.org/
+//! [`virtual machine`]: https://github.com/capsule-rs/sandbox/blob/master/Vagrantfile
+//! [`sandbox`]: https://hub.docker.com/repository/docker/getcapsule/sandbox
+//! [`DPDK 18.11`]: https://doc.dpdk.org/guides-18.11/rel_notes/release_18_11.html
+//! [`Clang`]: https://clang.llvm.org/
+//! [`LLVM`]: https://www.llvm.org/
+//! [`Rust 1.42`]: https://blog.rust-lang.org/2020/03/12/Rust-1.42.html
+//! [`rr`]: https://rr-project.org/
+//! [`README`]: https://github.com/capsule-rs/capsule/blob/master/README.md
+//! [`sandbox repo`]: https://github.com/capsule-rs/sandbox
+//! [`metrics`]: crate::metrics
+//! [`kni`]: https://github.com/capsule-rs/capsule/tree/master/examples/kni
+//! [`nat64`]: https://github.com/capsule-rs/capsule/tree/master/examples/nat64
+//! [`ping4d`]: https://github.com/capsule-rs/capsule/tree/master/examples/ping4d
+//! [`pktdump`]: https://github.com/capsule-rs/capsule/tree/master/examples/pktdump
+//! [`signals`]: https://github.com/capsule-rs/capsule/tree/master/examples/signals
+//! [`skeleton`]: https://github.com/capsule-rs/capsule/tree/master/examples/skeleton
+//! [`syn-flood`]: https://github.com/capsule-rs/capsule/tree/master/examples/syn-flood
+
 // alias for the test macro
 #[cfg(test)]
 extern crate self as capsule;
@@ -26,19 +118,23 @@ mod dpdk;
 mod ffi;
 mod macros;
 #[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "default", feature = "metrics"))))]
 pub mod metrics;
 pub mod net;
 pub mod packets;
 #[cfg(feature = "pcap-dump")]
-pub mod pcap;
+#[cfg_attr(docsrs, doc(cfg(feature = "pcap-dump")))]
+mod pcap;
 mod runtime;
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 pub mod testils;
 
 pub use self::batch::{Batch, Pipeline, Poll};
 pub use self::dpdk::{KniRx, KniTxQueue, Mbuf, PortQueue, SizeOf};
 pub use self::runtime::{Runtime, UnixSignal};
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 pub use capsule_macros::{bench, test};
 pub use capsule_macros::{Icmpv4Packet, Icmpv6Packet, SizeOf};
 

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -16,7 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-//! Exposes the following framework metrics.
+//! Exposes framework metrics, including port, kni, mempool, and pipeline
+//! metrics.
 //!
 //! # Port Metrics
 //!

--- a/core/src/net/cidr/mod.rs
+++ b/core/src/net/cidr/mod.rs
@@ -19,22 +19,32 @@
 mod v4;
 mod v6;
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::v4::Ipv4Cidr;
+#[allow(unreachable_pub)]
 pub use self::v6::Ipv6Cidr;
 
 use failure::Fail;
 use std::net::IpAddr;
 
+/// Error returned when parsing a malformed CIDR range.
 #[derive(Debug, Fail)]
 #[fail(display = "Failed to parse CIDR: {}", _0)]
 pub struct CidrParseError(String);
 
+/// Common behaviors for interacting with CIDR ranges.
 pub trait Cidr: Sized {
+    /// Type of address, i.e. IPv4 or IPv6, associated with the CIDR.
     type Addr;
 
+    /// IP address prefix.
     fn address(&self) -> Self::Addr;
+    /// CIDR Prefix length.
     fn length(&self) -> usize;
+    /// Creates a new CIDR range.
     fn new(address: Self::Addr, length: usize) -> Result<Self, CidrParseError>;
+    /// Checks whether an address is contained within the CIDR range.
     fn contains(&self, address: Self::Addr) -> bool;
+    /// Checks whether a generic IP address is contained within the CIDR range.
     fn contains_ip(&self, ip: IpAddr) -> bool;
 }

--- a/core/src/net/cidr/v4.rs
+++ b/core/src/net/cidr/v4.rs
@@ -23,6 +23,9 @@ use std::str::FromStr;
 
 const IPV4ADDR_BITS: usize = 32;
 
+/// [`CIDR`] range for IPv4 addresses.
+///
+/// [`CIDR`]: https://tools.ietf.org/html/rfc4632#section-3.1
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ipv4Cidr {
     address: Ipv4Addr,

--- a/core/src/net/cidr/v6.rs
+++ b/core/src/net/cidr/v6.rs
@@ -23,6 +23,9 @@ use std::str::FromStr;
 
 const IPV6ADDR_BITS: usize = 128;
 
+/// [`CIDR`] range for IPv6 addresses.
+///
+/// [`CIDR`]: https://tools.ietf.org/html/rfc4291#section-2.3
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ipv6Cidr {
     address: Ipv6Addr,

--- a/core/src/net/mac.rs
+++ b/core/src/net/mac.rs
@@ -21,20 +21,22 @@ use std::convert::From;
 use std::fmt;
 use std::str::FromStr;
 
-/// MAC address
+/// Ethernet MAC address.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(C, packed)]
 pub struct MacAddr([u8; 6]);
 
 impl MacAddr {
+    /// A MAC address representing an unspecified address: 00:00:00:00:00:00.
     pub const UNSPECIFIED: Self = MacAddr([0, 0, 0, 0, 0, 0]);
 
+    /// Creates a MAC address from 6 octets.
     #[allow(clippy::many_single_char_names)]
     pub fn new(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8) -> Self {
         MacAddr([a, b, c, d, e, f])
     }
 
-    /// Returns the six bytes the MAC address consists of
+    /// Returns the six bytes the MAC address consists of.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn octets(&self) -> [u8; 6] {
         self.0
@@ -57,6 +59,7 @@ impl From<[u8; 6]> for MacAddr {
     }
 }
 
+/// Error returned when parsing a malformed MAC address.
 #[derive(Debug, Fail)]
 #[fail(display = "Failed to parse '{}' as MAC address.", _0)]
 pub struct MacParseError(String);

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Common network utilities.
+
 mod cidr;
 mod mac;
 

--- a/core/src/packets/icmp/mod.rs
+++ b/core/src/packets/icmp/mod.rs
@@ -16,5 +16,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Internet Control Message Protocol for IPv4 and IPv6.
+
 pub mod v4;
 pub mod v6;

--- a/core/src/packets/icmp/v4/echo_reply.rs
+++ b/core/src/packets/icmp/v4/echo_reply.rs
@@ -21,7 +21,7 @@ use crate::packets::Packet;
 use crate::{Icmpv4Packet, Result, SizeOf};
 use std::fmt;
 
-/// Echo Reply Message defined in [IETF RFC 792].
+/// Echo Reply Message defined in [`IETF RFC 792`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -35,15 +35,14 @@ use std::fmt;
 /// +-+-+-+-+-
 /// ```
 ///
-/// Identifier      The identifier from the invoking Echo Request message.
+/// *Identifier*:       The identifier from the invoking Echo Request message.
 ///
-/// Sequence Number
-///                 The sequence number from the invoking Echo Request
-///                 message.
+/// *Sequence Number*:  The sequence number from the invoking Echo Request
+///                     message.
 ///
-/// Data            The data from the invoking Echo Request message.
+/// *Data*:             The data from the invoking Echo Request message.
 ///
-/// [IETF RFC 792]: https://tools.ietf.org/html/rfc792
+/// [`IETF RFC 792`]: https://tools.ietf.org/html/rfc792
 #[derive(Clone, Copy, Debug, Default, Icmpv4Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct EchoReply {

--- a/core/src/packets/icmp/v4/echo_request.rs
+++ b/core/src/packets/icmp/v4/echo_request.rs
@@ -21,7 +21,7 @@ use crate::packets::Packet;
 use crate::{Icmpv4Packet, Result, SizeOf};
 use std::fmt;
 
-/// Echo Request Message defined in [IETF RFC 792].
+/// Echo Request Message defined in [`IETF RFC 792`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -35,16 +35,15 @@ use std::fmt;
 /// +-+-+-+-+-
 /// ```
 ///
-/// Identifier      An identifier to aid in matching Echo Replies
-///                 to this Echo Request.  May be zero.
+/// *Identifier*:       An identifier to aid in matching Echo Replies
+///                     to this Echo Request.  May be zero.
 ///
-/// Sequence Number
-///                 A sequence number to aid in matching Echo Replies
-///                 to this Echo Request.  May be zero.
+/// *Sequence Number*:  A sequence number to aid in matching Echo Replies
+///                     to this Echo Request.  May be zero.
 ///
-/// Data            Zero or more octets of arbitrary data.
+/// *Data*:             Zero or more octets of arbitrary data.
 ///
-/// [IETF RFC 792]: https://tools.ietf.org/html/rfc792
+/// [`IETF RFC 792`]: https://tools.ietf.org/html/rfc792
 #[derive(Clone, Copy, Debug, Default, Icmpv4Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct EchoRequest {

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -215,11 +215,11 @@ pub mod Icmpv4Types {
 
     /// Message type for [`Echo Request`].
     ///
-    /// [`Echo Request`]: EchoRequest
+    /// [`Echo Request`]: crate::packets::icmp::v4::EchoRequest
     pub const EchoRequest: Icmpv4Type = Icmpv4Type(8);
     /// Message type for [`Echo Reply`].
     ///
-    /// [`Echo Reply`]: EchoReply
+    /// [`Echo Reply`]: crate::packets::icmp::v4::EchoReply
     pub const EchoReply: Icmpv4Type = Icmpv4Type(0);
 }
 

--- a/core/src/packets/icmp/v6/echo_reply.rs
+++ b/core/src/packets/icmp/v6/echo_reply.rs
@@ -22,7 +22,7 @@ use crate::packets::Packet;
 use crate::{Icmpv6Packet, Result, SizeOf};
 use std::fmt;
 
-/// Echo Reply Message defined in [IETF RFC 4443].
+/// Echo Reply Message defined in [`IETF RFC 4443`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -36,15 +36,14 @@ use std::fmt;
 /// +-+-+-+-+-
 /// ```
 ///
-/// Identifier      The identifier from the invoking Echo Request message.
+/// - *Identifier*:       The identifier from the invoking Echo Request message.
 ///
-/// Sequence Number
-///                 The sequence number from the invoking Echo Request
-///                 message.
+/// - *Sequence Number*:  The sequence number from the invoking Echo Request
+///                       message.
 ///
-/// Data            The data from the invoking Echo Request message.
+/// - *Data*:             The data from the invoking Echo Request message.
 ///
-/// [IETF RFC 4443]: https://tools.ietf.org/html/rfc4443#section-4.2
+/// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-4.2
 #[derive(Clone, Copy, Debug, Default, SizeOf, Icmpv6Packet)]
 #[repr(C, packed)]
 pub struct EchoReply {

--- a/core/src/packets/icmp/v6/echo_request.rs
+++ b/core/src/packets/icmp/v6/echo_request.rs
@@ -22,7 +22,7 @@ use crate::packets::Packet;
 use crate::{Icmpv6Packet, Result, SizeOf};
 use std::fmt;
 
-/// Echo Request Message defined in [IETF RFC 4443].
+/// Echo Request Message defined in [`IETF RFC 4443`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -36,16 +36,15 @@ use std::fmt;
 /// +-+-+-+-+-
 /// ```
 ///
-/// Identifier      An identifier to aid in matching Echo Replies
-///                 to this Echo Request.  May be zero.
+/// - *Identifier*:       An identifier to aid in matching Echo Replies
+///                       to this Echo Request.  May be zero.
 ///
-/// Sequence Number
-///                 A sequence number to aid in matching Echo Replies
-///                 to this Echo Request.  May be zero.
+/// - *Sequence Number*:  A sequence number to aid in matching Echo Replies
+///                       to this Echo Request.  May be zero.
 ///
-/// Data            Zero or more octets of arbitrary data.
+/// - *Data*:             Zero or more octets of arbitrary data.
 ///
-/// [IETF RFC 4443]: https://tools.ietf.org/html/rfc4443#section-4.1
+/// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-4.1
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct EchoRequest {

--- a/core/src/packets/icmp/v6/ndp/mod.rs
+++ b/core/src/packets/icmp/v6/ndp/mod.rs
@@ -16,6 +16,17 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! The Neighbor Discovery Protocol is a protocol used in IPv6, using ICMPv6
+//! messages and operates at the link layer of the Internet model, as
+//! per [`IETF RFC 4861`]. It defines three mechanisms:
+//!
+//! - Substitute of ARP for use in IPv6 domains.
+//! - Stateless auto-configuration, allowing nodes on the local link to
+//!   configure their IPv6 addresses by themselves.
+//! - Router redirection to IPv6 nodes
+//!
+//! [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861
+
 mod neighbor_advert;
 mod neighbor_solicit;
 mod options;

--- a/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
@@ -30,7 +30,7 @@ const R_FLAG: u8 = 0b1000_0000;
 const S_FLAG: u8 = 0b0100_0000;
 const O_FLAG: u8 = 0b0010_0000;
 
-/// Neighbor Advertisement Message defined in [IETF RFC 4861].
+/// Neighbor Advertisement Message defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -46,54 +46,87 @@ const O_FLAG: u8 = 0b0010_0000;
 /// +-+-+-+-+-+-+-+-+-+-+-+-
 /// ```
 ///
-/// R               Router flag.  When set, the R-bit indicates that
-///                 the sender is a router.  The R-bit is used by
-///                 Neighbor Unreachability Detection to detect a
-///                 router that changes to a host.
+/// - *R*:                          Router flag. When set, the R-bit
+///                                 indicates that the sender is a router.
+///                                 The R-bit is used by Neighbor
+///                                 Unreachability Detection to detect a
+///                                 router that changes to a host.
 ///
-/// S               Solicited flag.  When set, the S-bit indicates that
-///                 the advertisement was sent in response to a
-///                 Neighbor Solicitation from the Destination address.
-///                 The S-bit is used as a reachability confirmation
-///                 for Neighbor Unreachability Detection.  It MUST NOT
-///                 be set in multicast advertisements or in
-///                 unsolicited unicast advertisements.
+/// - *S*:                          Solicited flag. When set, the S-bit
+///                                 indicates that the advertisement was sent in
+///                                 response to a Neighbor Solicitation from the
+///                                 Destination address. The S-bit is used as a
+///                                 reachability confirmation for Neighbor
+///                                 Unreachability Detection. It *MUST NOT*
+///                                 be set in multicast advertisements or in
+///                                 unsolicited unicast advertisements.
 ///
-/// O               Override flag.  When set, the O-bit indicates that
-///                 the advertisement should override an existing cache
-///                 entry and update the cached link-layer address.
-///                 When it is not set the advertisement will not
-///                 update a cached link-layer address though it will
-///                 update an existing Neighbor Cache entry for which
-///                 no link-layer address is known.  It SHOULD NOT be
-///                 set in solicited advertisements for anycast
-///                 addresses and in solicited proxy advertisements.
-///                 It SHOULD be set in other solicited advertisements
-///                 and in unsolicited advertisements.
+/// - *O*:                          Override flag. When set, the O-bit
+///                                 indicates that the advertisement should
+///                                 override an existing cache entry and update
+///                                 the cached link-layer address. When it is
+///                                 not set the advertisement will not update a
+///                                 cached link-layer address though it will
+///                                 update an existing Neighbor Cache entry for
+///                                 which no link-layer address is known. It
+///                                 *SHOULD NOT* be set in solicited
+///                                 advertisements for anycast addresses and in
+///                                 solicited proxy advertisements. It *SHOULD*
+///                                 be set in other solicited advertisements and
+///                                 in unsolicited advertisements.
 ///
-/// Reserved        29-bit unused field.  It MUST be initialized to
-///                 zero by the sender and MUST be ignored by the
-///                 receiver.
+/// - *Reserved*:                   29-bit unused field. It *MUST* be
+///                                 initialized to zero by the sender and *MUST*
+///                                 be ignored by the receiver.
 ///
-/// Target Address
-///                 For solicited advertisements, the Target Address
-///                 field in the Neighbor Solicitation message that
-///                 prompted this advertisement.  For an unsolicited
-///                 advertisement, the address whose link-layer address
-///                 has changed.  The Target Address MUST NOT be a
-///                 multicast address.
+/// - *Target Address*:             For solicited advertisements, the Target
+///                                 Address field in the Neighbor Solicitation
+///                                 message that prompted this advertisement.
+///                                 For an unsolicited advertisement, the
+///                                 address whose link-layer address has changed.
+///                                 The Target Address *MUST NOT* be a
+///                                 multicast address.
 ///
 /// Possible options:
 ///
-///   Target link-layer address
-///                 The link-layer address for the target, i.e., the
-///                 sender of the advertisement.  This option MUST be
-///                 included on link layers that have addresses when
-///                 responding to multicast solicitations.  When
-///                 responding to a unicast Neighbor Solicitation this
-///                 option SHOULD be included.
+/// - *Target link-layer address*:  The link-layer address for the target, i.e.,
+///                                 the sender of the advertisement. This
+///                                 option *MUST* be included on link layers
+///                                 that have addresses when responding to
+///                                 multicast solicitations. When responding to
+///                                 a unicast Neighbor Solicitation this option
+///                                 *SHOULD* be included.
 ///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.4
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.4
+#[derive(Clone, Copy, Debug, Icmpv6Packet, SizeOf)]
+#[repr(C)]
+pub struct NeighborAdvertisement {
+    flags: u8,
+    reserved1: u8,
+    reserved2: u16,
+    target_addr: Ipv6Addr,
+}
+
+impl Default for NeighborAdvertisement {
+    fn default() -> NeighborAdvertisement {
+        NeighborAdvertisement {
+            flags: 0,
+            reserved1: 0,
+            reserved2: 0,
+            target_addr: Ipv6Addr::UNSPECIFIED,
+        }
+    }
+}
+
+impl Icmpv6Payload for NeighborAdvertisement {
+    #[inline]
+    fn msg_type() -> Icmpv6Type {
+        Icmpv6Types::NeighborAdvertisement
+    }
+}
+
+impl NdpPayload for NeighborAdvertisement {}
+
 impl<E: Ipv6Packet> Icmpv6<E, NeighborAdvertisement> {
     /// Returns a flag indicating the sender is a router.
     #[inline]
@@ -183,36 +216,6 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, NeighborAdvertisement> {
             .finish()
     }
 }
-
-/// The ICMPv6 payload for neighbor advertisement message.
-#[derive(Clone, Copy, Debug, Icmpv6Packet, SizeOf)]
-#[repr(C)]
-pub struct NeighborAdvertisement {
-    flags: u8,
-    reserved1: u8,
-    reserved2: u16,
-    target_addr: Ipv6Addr,
-}
-
-impl Default for NeighborAdvertisement {
-    fn default() -> NeighborAdvertisement {
-        NeighborAdvertisement {
-            flags: 0,
-            reserved1: 0,
-            reserved2: 0,
-            target_addr: Ipv6Addr::UNSPECIFIED,
-        }
-    }
-}
-
-impl Icmpv6Payload for NeighborAdvertisement {
-    #[inline]
-    fn msg_type() -> Icmpv6Type {
-        Icmpv6Types::NeighborAdvertisement
-    }
-}
-
-impl NdpPayload for NeighborAdvertisement {}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
@@ -24,7 +24,7 @@ use crate::{Icmpv6Packet, Result, SizeOf};
 use std::fmt;
 use std::net::Ipv6Addr;
 
-/// Neighbor Solicitation Message defined in [IETF RFC 4861].
+/// Neighbor Solicitation Message defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -40,24 +40,50 @@ use std::net::Ipv6Addr;
 /// +-+-+-+-+-+-+-+-+-+-+-+-
 /// ```
 ///
-/// Reserved        This field is unused.  It MUST be initialized to
-///                 zero by the sender and MUST be ignored by the
-///                 receiver.
+/// - *Reserved*:                   This field is unused. It *MUST* be
+///                                 initialized to zero by the sender and
+///                                 *MUST* be ignored by the receiver.
 ///
-/// Target Address  The IP address of the target of the solicitation.
-///                 It MUST NOT be a multicast address.
+/// - *Target Address*:             The IP address of the target of the
+///                                 solicitation. It *MUST NOT* be a
+///                                 multicast address.
 ///
 /// Possible options:
 ///
-///  Source link-layer address
-///                 The link-layer address for the sender.  MUST NOT be
-///                 included when the source IP address is the
-///                 unspecified address.  Otherwise, on link layers
-///                 that have addresses this option MUST be included in
-///                 multicast solicitations and SHOULD be included in
-///                 unicast solicitations.
+/// - *Source link-layer address*:  The link-layer address for the sender.
+///                                 *MUST NOT* be included when the source IP
+///                                 address is the unspecified address.
+///                                 Otherwise, on link layers that have
+///                                 addresses this option *MUST* be included in
+///                                 multicast solicitations and *SHOULD* be
+///                                 included in unicast solicitations.
 ///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.3
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.3
+#[derive(Clone, Copy, Debug, Icmpv6Packet, SizeOf)]
+#[repr(C)]
+pub struct NeighborSolicitation {
+    reserved: u32,
+    target_addr: Ipv6Addr,
+}
+
+impl Default for NeighborSolicitation {
+    fn default() -> NeighborSolicitation {
+        NeighborSolicitation {
+            reserved: 0,
+            target_addr: Ipv6Addr::UNSPECIFIED,
+        }
+    }
+}
+
+impl Icmpv6Payload for NeighborSolicitation {
+    #[inline]
+    fn msg_type() -> Icmpv6Type {
+        Icmpv6Types::NeighborSolicitation
+    }
+}
+
+impl NdpPayload for NeighborSolicitation {}
+
 impl<E: Ipv6Packet> Icmpv6<E, NeighborSolicitation> {
     #[inline]
     fn reserved(&self) -> u32 {
@@ -94,32 +120,6 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, NeighborSolicitation> {
             .finish()
     }
 }
-
-/// The ICMPv6 payload for neighbor solicitation message.
-#[derive(Clone, Copy, Debug, Icmpv6Packet, SizeOf)]
-#[repr(C)]
-pub struct NeighborSolicitation {
-    reserved: u32,
-    target_addr: Ipv6Addr,
-}
-
-impl Default for NeighborSolicitation {
-    fn default() -> NeighborSolicitation {
-        NeighborSolicitation {
-            reserved: 0,
-            target_addr: Ipv6Addr::UNSPECIFIED,
-        }
-    }
-}
-
-impl Icmpv6Payload for NeighborSolicitation {
-    #[inline]
-    fn msg_type() -> Icmpv6Type {
-        Icmpv6Types::NeighborSolicitation
-    }
-}
-
-impl NdpPayload for NeighborSolicitation {}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/packets/icmp/v6/ndp/options/link_layer_addr.rs
+++ b/core/src/packets/icmp/v6/ndp/options/link_layer_addr.rs
@@ -23,7 +23,7 @@ use crate::{ensure, Mbuf, Result, SizeOf};
 use std::fmt;
 use std::ptr::NonNull;
 
-/// Source/Target Link-layer Address option defined in [IETF RFC 4861].
+/// Source/Target Link-layer Address option defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -33,22 +33,20 @@ use std::ptr::NonNull;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Type            1 for Source Link-layer Address
-///                 2 for Target Link-layer Address
+/// - *Type*:                1 for Source Link-layer Address.
+///                          2 for Target Link-layer Address.
 ///
-/// Length          The length of the option (including the type and
-///                 length fields) in units of 8 octets.  For example,
-///                 the length for IEEE 802 addresses is 1.
+/// - *Length*:              The length of the option (including the type and
+///                          length fields) in units of 8 octets. For example,
+///                          the length for IEEE 802 addresses is 1.
 ///
-/// Link-Layer Address
-///                 The variable length link-layer address.
+/// - *Link-Layer Address*:  The variable length link-layer address.
+///                          The content and format of this field (including
+///                          byte and bit ordering) is expected to be specified
+///                          in specific documents that describe how IPv6
+///                          operates over different link layers.
 ///
-///                 The content and format of this field (including
-///                 byte and bit ordering) is expected to be specified
-///                 in specific documents that describe how IPv6
-///                 operates over different link layers.
-///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.6.1
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.6.1
 pub struct LinkLayerAddress {
     fields: NonNull<LinkLayerAddressFields>,
     offset: usize,

--- a/core/src/packets/icmp/v6/ndp/options/mod.rs
+++ b/core/src/packets/icmp/v6/ndp/options/mod.rs
@@ -20,25 +20,37 @@ mod link_layer_addr;
 mod mtu;
 mod prefix_info;
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::link_layer_addr::*;
+#[allow(unreachable_pub)]
 pub use self::mtu::*;
+#[allow(unreachable_pub)]
 pub use self::prefix_info::*;
 
 use crate::packets::ParseError;
 use crate::{Mbuf, Result};
 use fallible_iterator::FallibleIterator;
 
+/// Source link-layer address option.
 pub const SOURCE_LINK_LAYER_ADDR: u8 = 1;
+/// Target link-layer address option.
 pub const TARGET_LINK_LAYER_ADDR: u8 = 2;
+/// Prefix Information option.
 pub const PREFIX_INFORMATION: u8 = 3;
 //const REDIRECTED_HEADER: u8 = 4;
+/// MTU option.
 pub const MTU: u8 = 5;
 
 /// A parsed NDP option.
+#[derive(Debug)]
 pub enum NdpOptions {
+    /// Source link-layer address of a device.
     SourceLinkLayerAddress(LinkLayerAddress),
+    /// Target link-layer address of a device.
     TargetLinkLayerAddress(LinkLayerAddress),
+    /// Prefix information.
     PrefixInformation(PrefixInformation),
+    /// MTU information.
     Mtu(Mtu),
     /// An undefined NDP option.
     Undefined(u8, u8),
@@ -53,12 +65,14 @@ pub trait NdpOption {
 }
 
 /// NDP options iterator.
+#[allow(missing_debug_implementations)]
 pub struct NdpOptionsIterator<'a> {
     mbuf: &'a Mbuf,
     offset: usize,
 }
 
 impl<'a> NdpOptionsIterator<'a> {
+    /// Creates a new NDP options iterator.
     pub fn new(mbuf: &'a Mbuf, offset: usize) -> NdpOptionsIterator<'a> {
         NdpOptionsIterator { mbuf, offset }
     }
@@ -107,6 +121,7 @@ impl FallibleIterator for NdpOptionsIterator<'_> {
     }
 }
 
+/// ICMPv6 packet with invalid MTU-option length.
 #[cfg(test)]
 #[rustfmt::skip]
 const INVALID_OPTION_LENGTH: [u8;78] = [

--- a/core/src/packets/icmp/v6/ndp/options/mtu.rs
+++ b/core/src/packets/icmp/v6/ndp/options/mtu.rs
@@ -22,7 +22,7 @@ use crate::{ensure, Mbuf, Result, SizeOf};
 use std::fmt;
 use std::ptr::NonNull;
 
-/// MTU option defined in [IETF RFC 4861].
+/// MTU option defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -34,18 +34,18 @@ use std::ptr::NonNull;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Type            5
+/// - *Type*:            5
 ///
-/// Length          1
+/// - *Length*:          1
 ///
-/// Reserved        This field is unused.  It MUST be initialized to
-///                 zero by the sender and MUST be ignored by the
-///                 receiver.
+/// - *Reserved*:        This field is unused. It *MUST* be initialized to
+///                      zero by the sender and *MUST* be ignored by the
+///                      receiver.
 ///
-/// MTU             32-bit unsigned integer.  The recommended MTU for
-///                 the link.
+/// - *MTU*:             32-bit unsigned integer. The recommended MTU for
+///                      the link.
 ///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.6.4
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.6.4
 pub struct Mtu {
     fields: NonNull<MtuFields>,
     offset: usize,

--- a/core/src/packets/icmp/v6/ndp/options/prefix_info.rs
+++ b/core/src/packets/icmp/v6/ndp/options/prefix_info.rs
@@ -27,7 +27,7 @@ use std::ptr::NonNull;
 const ONLINK: u8 = 0b1000_0000;
 const AUTO: u8 = 0b0100_0000;
 
-/// Prefix Information option defined in [IETF RFC 4861].
+/// Prefix Information option defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -43,71 +43,72 @@ const AUTO: u8 = 0b0100_0000;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |                Prefix (128 bits IPv6 address)                 |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// ```
 ///
-/// Type            3
+/// - *Type*:                3
 ///
-/// Length          4
+/// - *Length*:              4
 ///
-/// Prefix Length   8-bit unsigned integer.  The number of leading bits
-///                 in the Prefix that are valid.  The value ranges
-///                 from 0 to 128.  The prefix length field provides
-///                 necessary information for on-link determination
-///                 (when combined with the L flag in the prefix
-///                 information option).  It also assists with address
-///                 autoconfiguration as specified in [ADDRCONF], for
-///                 which there may be more restrictions on the prefix
-///                 length.
+/// - *Prefix Length*:       8-bit unsigned integer. The number of leading bits
+///                          in the Prefix that are valid. The value ranges
+///                          from 0 to 128. The prefix length field provides
+///                          necessary information for on-link determination
+///                          (when combined with the L flag in the prefix
+///                          information option). It also assists with address
+///                          auto-configuration as specified in `ADDRCONF`, for
+///                          which there may be more restrictions on the prefix
+///                          length.
 ///
-/// L               1-bit on-link flag.  When set, indicates that this
-///                 prefix can be used for on-link determination.  When
-///                 not set the advertisement makes no statement about
-///                 on-link or off-link properties of the prefix.  In
-///                 other words, if the L flag is not set a host MUST
-///                 NOT conclude that an address derived from the
-///                 prefix is off-link.  That is, it MUST NOT update a
-///                 previous indication that the address is on-link.
+/// - *L*:                   1-bit on-link flag. When set, indicates that this
+///                          prefix can be used for on-link determination. When
+///                          not set the advertisement makes no statement about
+///                          on-link or off-link properties of the prefix. In
+///                          other words, if the L flag is not set a host
+///                          **MUST NOT** conclude that an address derived from
+///                          the prefix is off-link.  That is, it **MUST NOT**
+///                          update a previous indication that the address is
+///                          on-link.
 ///
-/// A               1-bit autonomous address-configuration flag.  When
-///                 set indicates that this prefix can be used for
-///                 stateless address configuration as specified in
-///                 [ADDRCONF].
+/// - *A*:                   1-bit autonomous address-configuration flag. When
+///                          set indicates that this prefix can be used for
+///                          stateless address configuration as specified in
+///                          `ADDRCONF`.
 ///
-/// Reserved1       6-bit unused field.  It MUST be initialized to zero
-///                 by the sender and MUST be ignored by the receiver.
+/// - *Reserved1*:           6-bit unused field. It **MUST** be initialized to
+///                          zero by the sender and **MUST** be ignored by the
+///                          receiver.
 ///
-/// Valid Lifetime
-///                 32-bit unsigned integer.  The length of time in
-///                 seconds (relative to the time the packet is sent)
-///                 that the prefix is valid for the purpose of on-link
-///                 determination.  A value of all one bits
-///                 (0xffffffff) represents infinity.  The Valid
-///                 Lifetime is also used by [ADDRCONF].
+/// - *Valid Lifetime*:      32-bit unsigned integer. The length of time in
+///                          seconds (relative to the time the packet is sent)
+///                          that the prefix is valid for the purpose of on-link
+///                          determination. A value of all one bits
+///                          (0xffffffff) represents infinity. The Valid
+///                          Lifetime is also used by `ADDRCONF`.
 ///
-/// Preferred Lifetime
-///                 32-bit unsigned integer.  The length of time in
-///                 seconds (relative to the time the packet is sent)
-///                 that addresses generated from the prefix via
-///                 stateless address autoconfiguration remain
-///                 preferred [ADDRCONF].  A value of all one bits
-///                 (0xffffffff) represents infinity.  See [ADDRCONF].
-///                 Note that the value of this field MUST NOT exceed
-///                 the Valid Lifetime field to avoid preferring
-///                 addresses that are no longer valid.
+/// - *Preferred Lifetime*:  32-bit unsigned integer. The length of time in
+///                          seconds (relative to the time the packet is sent)
+///                          that addresses generated from the prefix via
+///                          stateless address auto-configuration remain
+///                          preferred `ADDRCONF`.  A value of all one bits
+///                          (0xffffffff) represents infinity.  See `ADDRCONF`.
+///                          Note that the value of this field MUST NOT exceed
+///                          the Valid Lifetime field to avoid preferring
+///                          addresses that are no longer valid.
 ///
-/// Reserved2       This field is unused.  It MUST be initialized to
-///                 zero by the sender and MUST be ignored by the
-///                 receiver.
+/// - *Reserved2*:           This field is unused.  It MUST be initialized to
+///                          zero by the sender and MUST be ignored by the
+///                          receiver.
 ///
-/// Prefix          An IP address or a prefix of an IP address.  The
-///                 Prefix Length field contains the number of valid
-///                 leading bits in the prefix.  The bits in the prefix
-///                 after the prefix length are reserved and MUST be
-///                 initialized to zero by the sender and ignored by
-///                 the receiver.  A router SHOULD NOT send a prefix
-///                 option for the link-local prefix and a host SHOULD
-///                 ignore such a prefix option.
+/// - *Prefix*:              An IP address or a prefix of an IP address.  The
+///                          Prefix Length field contains the number of valid
+///                          leading bits in the prefix. The bits in the prefix
+///                          after the prefix length are reserved and MUST be
+///                          initialized to zero by the sender and ignored by
+///                          the receiver. A router *SHOULD NOT* send a prefix
+///                          option for the link-local prefix and a host *SHOULD*
+///                          ignore such a prefix option.
 ///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.6.2
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.6.2
 pub struct PrefixInformation {
     fields: NonNull<PrefixInformationFields>,
     offset: usize,

--- a/core/src/packets/icmp/v6/ndp/router_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/router_advert.rs
@@ -26,7 +26,7 @@ use std::fmt;
 const M_FLAG: u8 = 0b1000_0000;
 const O_FLAG: u8 = 0b0100_0000;
 
-/// Router Advertisement Message defined in [IETF RFC 4861].
+/// Router Advertisement Message defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -44,89 +44,114 @@ const O_FLAG: u8 = 0b0100_0000;
 /// +-+-+-+-+-+-+-+-+-+-+-+-
 /// ```
 ///
-/// Cur Hop Limit   8-bit unsigned integer.  The default value that
-///                 should be placed in the Hop Count field of the IP
-///                 header for outgoing IP packets.  A value of zero
-///                 means unspecified (by this router).
+/// - *Cur Hop Limit*:              8-bit unsigned integer. The default value
+///                                 that should be placed in the Hop Count field
+///                                 of the IP header for outgoing IP packets. A
+///                                 value of zero means unspecified (by this
+///                                 router).
 ///
-/// M               1-bit "Managed address configuration" flag.  When
-///                 set, it indicates that addresses are available via
-///                 Dynamic Host Configuration Protocol [DHCPv6].
+/// - *M*:                          1-bit "Managed address configuration" flag.
+///                                 When set, it indicates that addresses are
+///                                 available via Dynamic Host Configuration
+///                                 Protocol (DHCPv6). *Note*: If the M flag is
+///                                 set, the O flag is redundant and can be
+///                                 ignored because DHCPv6 will return all
+///                                 available configuration information.
 ///
-///                 If the M flag is set, the O flag is redundant and
-///                 can be ignored because DHCPv6 will return all
-///                 available configuration information.
+/// - *O*:                          1-bit "Other configuration" flag. When set,
+///                                 it indicates that other configuration
+///                                 information is available via DHCPv6.
+///                                 Examples of such information are DNS-related
+///                                 information or information on other servers
+///                                 within the network.
 ///
-/// O               1-bit "Other configuration" flag.  When set, it
-///                 indicates that other configuration information is
-///                 available via DHCPv6.  Examples of such information
-///                 are DNS-related information or information on other
-///                 servers within the network.
+/// Note: If neither M nor O flags are set, this indicates that no
+///         information is available via DHCPv6.
 ///
-///   Note: If neither M nor O flags are set, this indicates that no
-///   information is available via DHCPv6.
+/// - *Reserved*                    A 6-bit unused field. It *MUST* be
+///                                 initialized to zero by the sender and
+///                                 *MUST* be ignored by the receiver.
 ///
-/// Reserved        A 6-bit unused field.  It MUST be initialized to
-///                 zero by the sender and MUST be ignored by the
-///                 receiver.
+/// - *Router Lifetime*:            16-bit unsigned integer. The lifetime
+///                                 associated with the default router in units
+///                                 of seconds. The field can contain values up
+///                                 to 65535 and receivers should handle any
+///                                 value, while the sending rules in Section 6
+///                                 limit the lifetime to 9000 seconds. A
+///                                 Lifetime of 0 indicates that the router is
+///                                 not a default router and *SHOULD NOT* appear
+///                                 on the default router list. The Router
+///                                 Lifetime applies only to the router's
+///                                 usefulness as a default router; it does not
+///                                 apply to information contained in other
+///                                 message fields or options. Options that need
+///                                 time limits for their information include
+///                                 their own lifetime fields.
 ///
-/// Router Lifetime
-///                 16-bit unsigned integer.  The lifetime associated
-///                 with the default router in units of seconds.  The
-///                 field can contain values up to 65535 and receivers
-///                 should handle any value, while the sending rules in
-///                 Section 6 limit the lifetime to 9000 seconds.  A
-///                 Lifetime of 0 indicates that the router is not a
-///                 default router and SHOULD NOT appear on the default
-///                 router list.  The Router Lifetime applies only to
-///                 the router's usefulness as a default router; it
-///                 does not apply to information contained in other
-///                 message fields or options.  Options that need time
-///                 limits for their information include their own
-///                 lifetime fields.
+/// - *Reachable Time*:             32-bit unsigned integer. The time, in
+///                                 milliseconds, that a node assumes a neighbor
+///                                 is reachable after having received a
+///                                 reachability confirmation. Used by the
+///                                 Neighbor Unreachability Detection algorithm
+///                                 (see Section 7.3).  A value of zero means
+///                                 unspecified (by this router).
 ///
-/// Reachable Time  32-bit unsigned integer.  The time, in
-///                 milliseconds, that a node assumes a neighbor is
-///                 reachable after having received a reachability
-///                 confirmation.  Used by the Neighbor Unreachability
-///                 Detection algorithm (see Section 7.3).  A value of
-///                 zero means unspecified (by this router).
-///
-/// Retrans Timer   32-bit unsigned integer.  The time, in
-///                 milliseconds, between retransmitted Neighbor
-///                 Solicitation messages.  Used by address resolution
-///                 and the Neighbor Unreachability Detection algorithm
-///                 (see Sections 7.2 and 7.3).  A value of zero means
-///                 unspecified (by this router).
+/// - *Retrans Timer*:              32-bit unsigned integer.  The time, in
+///                                 milliseconds, between retransmitted Neighbor
+///                                 Solicitation messages.  Used by address
+///                                 resolution and the Neighbor Unreachability
+///                                 Detection algorithm (see Sections 7.2
+///                                 and 7.3).  A value of zero means unspecified
+///                                 (by this router).
 ///
 /// Possible options:
 ///
-/// Source link-layer address
-///                 The link-layer address of the interface from which
-///                 the Router Advertisement is sent.  Only used on
-///                 link layers that have addresses.  A router MAY omit
-///                 this option in order to enable inbound load sharing
-///                 across multiple link-layer addresses.
+/// - *Source link-layer address*:  The link-layer address of the interface from
+///                                 which the Router Advertisement is sent. Only
+///                                 used on link layers that have addresses. A
+///                                 router MAY omit this option in order to
+///                                 enable inbound load sharing across multiple
+///                                 link-layer addresses.
 ///
-/// MTU             SHOULD be sent on links that have a variable MTU
-///                 (as specified in the document that describes how to
-///                 run IP over the particular link type).  MAY be sent
-///                 on other links.
+/// - *MTU*:                        *SHOULD* be sent on links that have a
+///                                 variable MTU (as specified in the document
+///                                 that describes how to run IP over the
+///                                 particular link type). *MAY* be sent on
+///                                 other links.
 ///
-/// Prefix Information
-///                 These options specify the prefixes that are on-link
-///                 and/or are used for stateless address
-///                 autoconfiguration.  A router SHOULD include all its
-///                 on-link prefixes (except the link-local prefix) so
-///                 that multihomed hosts have complete prefix
-///                 information about on-link destinations for the
-///                 links to which they attach.  If complete
-///                 information is lacking, a host with multiple
-///                 interfaces may not be able to choose the correct
-///                 outgoing interface when sending traffic to its
-///                 neighbors.
+/// - *Prefix Information*:         These options specify the prefixes that are
+///                                 on-link and/or are used for stateless
+///                                 address auto-configuration. A router *SHOULD*
+///                                 include all its on-link prefixes (except the
+///                                 link-local prefix) so that multihomed hosts
+///                                 have complete prefix information about
+///                                 on-link destinations for the links to which
+///                                 they attach. If complete information is
+///                                 lacking, a host with multiple interfaces may
+///                                 not be able to choose the correct outgoing
+///                                 interface when sending traffic to its
+///                                 neighbors.
 ///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.2
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.2
+#[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
+#[repr(C, packed)]
+pub struct RouterAdvertisement {
+    current_hop_limit: u8,
+    flags: u8,
+    router_lifetime: u16,
+    reachable_time: u32,
+    retrans_timer: u32,
+}
+
+impl Icmpv6Payload for RouterAdvertisement {
+    #[inline]
+    fn msg_type() -> Icmpv6Type {
+        Icmpv6Types::RouterAdvertisement
+    }
+}
+
+impl NdpPayload for RouterAdvertisement {}
+
 impl<E: Ipv6Packet> Icmpv6<E, RouterAdvertisement> {
     /// Returns the current hop limit.
     #[inline]
@@ -240,27 +265,9 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, RouterAdvertisement> {
     }
 }
 
-/// The ICMPv6 payload for router advertisement message.
-#[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
-#[repr(C, packed)]
-pub struct RouterAdvertisement {
-    current_hop_limit: u8,
-    flags: u8,
-    router_lifetime: u16,
-    reachable_time: u32,
-    retrans_timer: u32,
-}
-
-impl Icmpv6Payload for RouterAdvertisement {
-    #[inline]
-    fn msg_type() -> Icmpv6Type {
-        Icmpv6Types::RouterAdvertisement
-    }
-}
-
-impl NdpPayload for RouterAdvertisement {}
-
-#[cfg(test)]
+/// ICMPv6 Router Advertisement packet as byte-array.
+#[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const ROUTER_ADVERT_PACKET: [u8; 142] = [
 // ethernet header

--- a/core/src/packets/icmp/v6/ndp/router_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/router_solicit.rs
@@ -23,7 +23,7 @@ use crate::packets::Packet;
 use crate::{Icmpv6Packet, Result, SizeOf};
 use std::fmt;
 
-/// Router Solicitation Message defined in [IETF RFC 4861].
+/// Router Solicitation Message defined in [`IETF RFC 4861`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -37,21 +37,38 @@ use std::fmt;
 /// +-+-+-+-+-+-+-+-+-+-+-+-
 /// ```
 ///
-/// Reserved        This field is unused.  It MUST be initialized to
-///                 zero by the sender and MUST be ignored by the
-///                 receiver.
+/// - *Reserved*:                   This field is unused. It *MUST* be
+///                                 initialized to zero by the sender and
+///                                 *MUST* be ignored by the receiver.
 ///
 /// Valid Options:
 ///
-/// Source link-layer address
-///                 The link-layer address of the sender, if
-///                 known.  MUST NOT be included if the Source Address
-///                 is the unspecified address.  Otherwise, it SHOULD
-///                 be included on link layers that have addresses.
+/// - *Source link-layer address*:  The link-layer address of the sender, if
+///                                 known. *MUST NOT* be included if the
+///                                 Source Address is the unspecified address.
+///                                 Otherwise, it *SHOULD* be included on link
+///                                 layers that have addresses.
 ///
-/// [IETF RFC 4861]: https://tools.ietf.org/html/rfc4861#section-4.1
+/// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.1
+#[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
+#[repr(C, packed)]
+pub struct RouterSolicitation {
+    reserved: u32,
+}
+
+impl Icmpv6Payload for RouterSolicitation {
+    #[inline]
+    fn msg_type() -> Icmpv6Type {
+        Icmpv6Types::RouterSolicitation
+    }
+}
+
+impl NdpPayload for RouterSolicitation {}
+
 impl<E: Ipv6Packet> Icmpv6<E, RouterSolicitation> {
     #[inline]
+    /// Unused field that must be initialized to zero by sender and ignored
+    /// by the receiver.
     pub fn reserved(&self) -> u32 {
         u32::from_be(self.payload().reserved)
     }
@@ -74,23 +91,9 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, RouterSolicitation> {
     }
 }
 
-/// The ICMPv6 payload for router solicitation message.
-#[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
-#[repr(C, packed)]
-pub struct RouterSolicitation {
-    reserved: u32,
-}
-
-impl Icmpv6Payload for RouterSolicitation {
-    #[inline]
-    fn msg_type() -> Icmpv6Type {
-        Icmpv6Types::RouterSolicitation
-    }
-}
-
-impl NdpPayload for RouterSolicitation {}
-
-#[cfg(test)]
+/// ICMPv6 Router Solicitation packet as byte-array.
+#[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const ROUTER_SOLICIT_PACKET: [u8; 70] = [
     // ** ethernet header

--- a/core/src/packets/icmp/v6/time_exceeded.rs
+++ b/core/src/packets/icmp/v6/time_exceeded.rs
@@ -22,7 +22,7 @@ use crate::packets::Packet;
 use crate::{Icmpv6Packet, Result, SizeOf};
 use std::fmt;
 
-/// Time Exceeded Message defined in [IETF RFC 4443].
+/// Time Exceeded Message defined in [`IETF RFC 4443`].
 ///
 /// ```
 /// 0                   1                   2                   3
@@ -37,7 +37,7 @@ use std::fmt;
 /// |               exceeding the minimum IPv6 MTU [IPv6]           |
 /// ```
 ///
-/// [IETF RFC 4443]: https://tools.ietf.org/html/rfc4443#section-3.3
+/// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-3.3
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct TimeExceeded {

--- a/core/src/packets/icmp/v6/too_big.rs
+++ b/core/src/packets/icmp/v6/too_big.rs
@@ -22,7 +22,7 @@ use crate::packets::Packet;
 use crate::{Icmpv6Packet, Result, SizeOf};
 use std::fmt;
 
-/// Packet Too Big Message defined in [IETF RFC 4443].
+/// Packet Too Big Message defined in [`IETF RFC 4443`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -37,9 +37,9 @@ use std::fmt;
 /// |               exceeding the minimum IPv6 MTU [IPv6]           |
 /// ```
 ///
-/// MTU            The Maximum Transmission Unit of the next-hop link.
+/// - *MTU*:        The Maximum Transmission Unit of the next-hop link.
 ///
-/// [IETF RFC 4443]: https://tools.ietf.org/html/rfc4443#section-3.2
+/// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-3.2
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct PacketTooBig {

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Internet Protocol v4 and v6.
+
 pub mod v4;
 pub mod v6;
 
@@ -26,19 +28,23 @@ use failure::Fail;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 
-/// [IANA] recommended default TTL for IP.
+/// [`IANA`] recommended default TTL for IP.
 ///
-/// [IANA]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xml#ip-parameters-2
+/// [`IANA`]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xml#ip-parameters-2
 pub const DEFAULT_IP_TTL: u8 = 64;
 
-/// [IANA] assigned internet protocol number.
+/// [`IANA`] assigned Internet protocol number.
 ///
-/// [IANA]: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+/// See [`ProtocolNumbers`] for which are current supported.
+///
+/// [`IANA`]: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+/// [`ProtocolNumbers`]: crate::packets::ip::ProtocolNumbers
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[repr(C, packed)]
 pub struct ProtocolNumber(pub u8);
 
 impl ProtocolNumber {
+    /// Creates a new protocol number.
     pub fn new(value: u8) -> Self {
         ProtocolNumber(value)
     }
@@ -50,22 +56,22 @@ impl ProtocolNumber {
 pub mod ProtocolNumbers {
     use super::ProtocolNumber;
 
-    // Transmission Control Protocol.
+    /// Transmission Control Protocol.
     pub const Tcp: ProtocolNumber = ProtocolNumber(0x06);
 
-    // User Datagram Protocol.
+    /// User Datagram Protocol.
     pub const Udp: ProtocolNumber = ProtocolNumber(0x11);
 
-    // Routing Header for IPv6.
+    /// Routing Header for IPv6.
     pub const Ipv6Route: ProtocolNumber = ProtocolNumber(0x2B);
 
-    // Fragment Header for IPv6.
+    /// Fragment Header for IPv6.
     pub const Ipv6Frag: ProtocolNumber = ProtocolNumber(0x2C);
 
-    // Internet Control Message Protocol for IPv6.
+    /// Internet Control Message Protocol for IPv6.
     pub const Icmpv6: ProtocolNumber = ProtocolNumber(0x3A);
 
-    // Internet Control Message Protocol for IPv4.
+    /// Internet Control Message Protocol for IPv4.
     pub const Icmpv4: ProtocolNumber = ProtocolNumber(0x01);
 }
 
@@ -251,7 +257,7 @@ impl fmt::Debug for Flow {
     }
 }
 
-/// IpPacket errors.
+/// IpPacket-related errors.
 #[derive(Debug, Fail)]
 pub enum IpPacketError {
     /// Error indicating mixing IPv4 and IPv6 addresses in a flow.

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Internet Protocol v4.
+
 use crate::packets::checksum::{self, PseudoHeader};
 use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
 use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
@@ -24,13 +26,13 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ptr::NonNull;
 
-/// The minimum IPv4 MTU defined in [IETF RFC 791].
+/// The minimum IPv4 MTU defined in [`IETF RFC 791`].
 ///
 /// Every internet module must be able to forward a datagram of 68 octets
 /// without further fragmentation.  This is because an internet header may
 /// be up to 60 octets, and the minimum fragment is 8 octets.
 ///
-/// [IETF RFC 791]: https://tools.ietf.org/html/rfc791
+/// [`IETF RFC 791`]: https://tools.ietf.org/html/rfc791
 pub const IPV4_MIN_MTU: usize = 68;
 
 // Masks.
@@ -39,7 +41,7 @@ const ECN: u8 = !DSCP;
 const FLAGS_DF: u16 = 0b0100_0000_0000_0000;
 const FLAGS_MF: u16 = 0b0010_0000_0000_0000;
 
-/// Internet Protocol v4 based on [IETF RFC 791].
+/// Internet Protocol v4 based on [`IETF RFC 791`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -59,85 +61,85 @@ const FLAGS_MF: u16 = 0b0010_0000_0000_0000;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Version:  4 bits
-///     The Version field indicates the format of the internet header.  This
-///     document describes version 4.
+/// - *Version*: (4 bits)
+///      The Version field indicates the format of the internet header. This
+///      document describes version 4.
 ///
-/// IHL:  4 bits
-///     Internet Header Length is the length of the internet header in 32
-///     bit words, and thus points to the beginning of the data.  Note that
-///     the minimum value for a correct header is 5.
+/// - *IHL*: (4 bits)
+///      Internet Header Length is the length of the internet header in 32
+///      bit words, and thus points to the beginning of the data. Note that
+///      the minimum value for a correct header is 5.
 ///
-/// DSCP:  6 bits
-///     Differentiated services codepoint defined in [IETF RFC 2474]. Used to
-///     select the per hop behavior a packet experiences at each node.
+/// - *DSCP*: (6 bits)
+///      Differentiated services codepoint defined in [`IETF RFC 2474`]. Used to
+///      select the per hop behavior a packet experiences at each node.
 ///
-/// ECN:   2 bits
-///     Explicit congestion notification codepoint defined in [IETF RFC 3168].
+/// - *ECN*: (2 bits)
+///      Explicit congestion notification codepoint defined in [`IETF RFC 3168`].
 ///
-/// Total Length:  16 bits
-///     Total Length is the length of the datagram, measured in octets,
-///     including internet header and data.
+/// - *Total Length*: (16 bits)
+///      Total Length is the length of the datagram, measured in octets,
+///      including internet header and data.
 ///
-/// Identification:  16 bits
-///     An identifying value assigned by the sender to aid in assembling the
-///     fragments of a datagram.
+/// - *Identification*: (16 bits)
+///      An identifying value assigned by the sender to aid in assembling the
+///      fragments of a datagram.
 ///
-/// Flags:  3 bits
-///     Various Control Flags.
+/// - *Flags*: (3 bits)
+///      Various Control Flags.
 ///
-///     Bit 0: reserved, must be zero
-///     Bit 1: (DF) 0 = May Fragment,  1 = Don't Fragment.
-///     Bit 2: (MF) 0 = Last Fragment, 1 = More Fragments.
+///      - Bit 0: reserved, must be zero
+///      - Bit 1: (DF) 0 = May Fragment,  1 = Don't Fragment.
+///      - Bit 2: (MF) 0 = Last Fragment, 1 = More Fragments.
 ///
-///       0   1   2
-///     +---+---+---+
-///     |   | D | M |
-///     | 0 | F | F |
-///     +---+---+---+
+///              0   1   2
+///            +---+---+---+
+///            |   | D | M |
+///            | 0 | F | F |
+///            +---+---+---+
 ///
-/// Fragment Offset:  13 bits
-///     This field indicates where in the datagram this fragment belongs.
-///     The fragment offset is measured in units of 8 octets (64 bits).  The
-///     first fragment has offset zero.
+/// - *Fragment Offset*: (13 bits)
+///      This field indicates where in the datagram this fragment belongs.
+///      The fragment offset is measured in units of 8 octets (64 bits). The
+///      first fragment has offset zero.
 ///
-/// Time to Live:  8 bits
-///     This field indicates the maximum time the datagram is allowed to
-///     remain in the internet system.  If this field contains the value
-///     zero, then the datagram must be destroyed.  This field is modified
-///     in internet header processing.  The time is measured in units of
-///     seconds, but since every module that processes a datagram must
-///     decrease the TTL by at least one even if it process the datagram in
-///     less than a second, the TTL must be thought of only as an upper
-///     bound on the time a datagram may exist.  The intention is to cause
-///     undeliverable datagrams to be discarded, and to bound the maximum
-///     datagram lifetime.
+/// - *Time to Live*: (8 bits)
+///      This field indicates the maximum time the datagram is allowed to
+///      remain in the internet system. If this field contains the value
+///      zero, then the datagram must be destroyed. This field is modified
+///      in internet header processing. The time is measured in units of
+///      seconds, but since every module that processes a datagram must
+///      decrease the TTL by at least one even if it process the datagram in
+///      less than a second, the TTL must be thought of only as an upper
+///      bound on the time a datagram may exist. The intention is to cause
+///      undeliverable datagrams to be discarded, and to bound the maximum
+///      datagram lifetime.
 ///
-/// Protocol:  8 bits
-///     This field indicates the next level protocol used in the data
-///     portion of the internet datagram.  The values for various protocols
-///     are specified in "Assigned Numbers".
+/// - *Protocol*: (8 bits)
+///      This field indicates the next level protocol used in the data
+///      portion of the internet datagram. The values for various protocols
+///      are specified in "Assigned Numbers."
 ///
-/// Header Checksum:  16 bits
-///     A checksum on the header only.  Since some header fields change
-///     (e.g., time to live), this is recomputed and verified at each point
-///     that the internet header is processed.
+/// - *Header Checksum*: (16 bits)
+///      A checksum on the header only. Since some header fields change
+///      (e.g., time to live), this is recomputed and verified at each point
+///      that the internet header is processed.
 ///
-/// Source Address:  32 bits
-///     The source address.
+/// - *Source Address*: (32 bits)
+///      The source address.
 ///
-/// Destination Address:  32 bits
-///     The destination address.
+/// - *Destination Address*: (32 bits)
+///      The destination address.
 ///
-/// Options:  variable
-///     The options may appear or not in datagrams.  They must be
-///     implemented by all IP modules (host and gateways).  What is optional
-///     is their transmission in any particular datagram, not their
-///     implementation.
+/// - *Options*:  (variable)
+///      The options may appear or not in datagrams. They must be
+///      implemented by all IP modules (host and gateways). What is optional
+///      is their transmission in any particular datagram, not their
+///      implementation.
 ///
-/// [IETF RFC 791]: https://tools.ietf.org/html/rfc791#section-3.1
-/// [IETF RFC 2474]: https://tools.ietf.org/html/rfc2474
-/// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
+/// [`IETF RFC 791`]: https://tools.ietf.org/html/rfc791#section-3.1
+/// [`IETF RFC 2474`]: https://tools.ietf.org/html/rfc2474
+/// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
 #[derive(Clone)]
 pub struct Ipv4 {
     envelope: CondRc<Ethernet>,
@@ -527,7 +529,7 @@ impl IpPacket for Ipv4 {
             IpPacketError::MtuTooSmall(mtu, IPV4_MIN_MTU)
         );
 
-        // accounts for the ethernet frame length.
+        // accounts for the Ethernet frame length.
         let to_len = mtu + self.offset();
         self.mbuf_mut().truncate(to_len)
     }

--- a/core/src/packets/ip/v6/fragment.rs
+++ b/core/src/packets/ip/v6/fragment.rs
@@ -29,7 +29,7 @@ use std::ptr::NonNull;
 const FRAG_OS: u16 = !0b111;
 const FLAG_MORE: u16 = 0b1;
 
-/// IPv6 Fragment Extension packet based on [IETF RFC 8200].
+/// IPv6 Fragment Extension packet based on [`IETF RFC 8200`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -41,25 +41,25 @@ const FLAG_MORE: u16 = 0b1;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Next Header         8-bit selector.  Identifies the initial header
-///                     type of the Fragmentable Part of the original
-///                     packet (defined below).  Uses the same values
-///                     as the IPv4 Protocol field [IANA-PN].
+/// - *Next Header*:      8-bit selector.  Identifies the initial header
+///                       type of the Fragmentable Part of the original
+///                       packet. Uses the same values as the IPv4 Protocol
+///                       field [IANA-PN].
 ///
-/// Reserved            8-bit reserved field.  Initialized to zero for
-///                     transmission; ignored on reception.
+/// - *Reserved*:         8-bit reserved field.  Initialized to zero for
+///                       transmission; ignored on reception.
 ///
-/// Fragment Offset     13-bit unsigned integer.  The offset, in
-///                     8-octet units, of the data following this
-///                     header, relative to the start of the
-///                     Fragmentable Part of the original packet.
+/// - *Fragment Offset*:  13-bit unsigned integer.  The offset, in
+///                       8-octet units, of the data following this
+///                       header, relative to the start of the
+///                       Fragmentable Part of the original packet.
 ///
-/// Res                 2-bit reserved field.  Initialized to zero for
-///                     transmission; ignored on reception.
+/// - *Res*:              2-bit reserved field.  Initialized to zero for
+///                       transmission; ignored on reception.
 ///
-/// M flag              1 = more fragments; 0 = last fragment.
+/// - *M flag*:           1 = more fragments; 0 = last fragment.
 ///
-/// Identification      32 bits.  See description below.
+/// - *Identification*:   32 bits.
 ///
 /// # Remarks
 ///
@@ -67,7 +67,7 @@ const FLAG_MORE: u16 = 0b1;
 /// `push` and `remove` should be used with care. The result is likely not
 /// a valid packet without additional fixes.
 ///
-/// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-4.5
+/// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-4.5
 #[derive(Clone)]
 pub struct Fragment<E: Ipv6Packet> {
     envelope: CondRc<E>,
@@ -284,7 +284,9 @@ pub struct FragmentHeader {
 
 impl Header for FragmentHeader {}
 
+/// IPv6 fragment packet as byte-array.
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const FRAGMENT_PACKET: [u8; 72] = [
 // ethernet header

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Internet Protocol v6 and extension headers.
+
 mod fragment;
 mod srh;
 
@@ -30,9 +32,9 @@ use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
 
-/// The minimum IPv6 MTU defined in [IETF RFC 2460].
+/// The minimum IPv6 MTU defined in [`IETF RFC 2460`].
 ///
-/// [IETF RFC 2460]: https://tools.ietf.org/html/rfc2460#section-5
+/// [`IETF RFC 2460`]: https://tools.ietf.org/html/rfc2460#section-5
 pub const IPV6_MIN_MTU: usize = 1280;
 
 // Masks
@@ -40,7 +42,7 @@ const DSCP: u32 = 0x0fc0_0000;
 const ECN: u32 = 0x0030_0000;
 const FLOW: u32 = 0xfffff;
 
-/// Internet Protocol v6 based on [IETF RFC 8200].
+/// Internet Protocol v6 based on [`IETF RFC 8200`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -56,42 +58,41 @@ const FLOW: u32 = 0xfffff;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Version             4-bit Internet Protocol version number = 6.
+/// - *Version*:              4-bit Internet Protocol version number = 6.
 ///
-/// DSCP                6-bit Differentiated services codepoint defined
-///                     in [IETF RFC 2474]. Used to select the per hop
-///                     behavior a packet experiences at each node.
+/// - *DSCP*:                 6-bit Differentiated services codepoint defined
+///                           in [`IETF RFC 2474`]. Used to select the per hop
+///                           behavior a packet experiences at each node.
 ///
-/// ECN                 2-bit Explicit congestion notification codepoint
-///                     defined in [IETF RFC 3168].
+/// - *ECN*:                  2-bit Explicit congestion notification codepoint
+///                           defined in [`IETF RFC 3168`].
 ///
-/// Flow Label          20-bit flow label.
+/// - *Flow Label*:           20-bit flow label.
 ///
-/// Payload Length      16-bit unsigned integer.  Length of the IPv6
-///                     payload, i.e., the rest of the packet following
-///                     this IPv6 header, in octets.  (Note that any
-///                     extension headers present are considered part of
-///                     the payload, i.e., included in the length count.)
+/// - *Payload Length*:       16-bit unsigned integer.  Length of the IPv6
+///                           payload, i.e., the rest of the packet following
+///                           this IPv6 header, in octets. (*Note* that any
+///                           extension headers present are considered part of
+///                           the payload, i.e., included in the length count.)
 ///
-/// Next Header         8-bit selector.  Identifies the type of header
-///                     immediately following the IPv6 header.  Uses the
-///                     same values as the IPv4 Protocol field [RFC-1700
-///                     et seq.].
+/// - *Next Header*:          8-bit selector.  Identifies the type of header
+///                           immediately following the IPv6 header. Uses the
+///                           same values as the IPv4 Protocol field
+///                           [RFC-1700 et seq.].
 ///
-/// Hop Limit           8-bit unsigned integer.  Decremented by 1 by
-///                     each node that forwards the packet. The packet
-///                     is discarded if Hop Limit is decremented to
-///                     zero.
+/// - *Hop Limit*:            8-bit unsigned integer. Decremented by 1 by
+///                           each node that forwards the packet. The packet
+///                           is discarded if Hop Limit is decremented to zero.
 ///
-/// Source Address      128-bit address of the originator of the packet.
+/// - *Source Address*:       128-bit address of the originator of the packet.
 ///
-/// Destination Address 128-bit address of the intended recipient of the
-///                     packet (possibly not the ultimate recipient, if
-///                     a Routing header is present).
+/// - *Destination Address*:  128-bit address of the intended recipient of the
+///                           packet (possibly not the ultimate recipient, if
+///                           a Routing header is present).
 ///
-/// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-3
-/// [IETF RFC 2474]: https://tools.ietf.org/html/rfc2474
-/// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
+/// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-3
+/// [`IETF RFC 2474`]: https://tools.ietf.org/html/rfc2474
+/// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
 #[derive(Clone)]
 pub struct Ipv6 {
     envelope: CondRc<Ethernet>,
@@ -366,7 +367,7 @@ impl IpPacket for Ipv6 {
             IpPacketError::MtuTooSmall(mtu, IPV6_MIN_MTU)
         );
 
-        // accounts for the ethernet frame length.
+        // accounts for the Ethernet frame length.
         let to_len = mtu + self.offset();
         self.mbuf_mut().truncate(to_len)
     }
@@ -420,10 +421,12 @@ impl Default for Ipv6Header {
 
 impl Header for Ipv6Header {}
 
+/// IPv6 TCP packet as byte-array.
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const IPV6_PACKET: [u8; 78] = [
-// ethernet header
+// Ethernet header
     0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
     0x86, 0xDD,

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -26,9 +26,9 @@ use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
 
-/// IPv6 Segment Routing based on [IETF DRAFT].
+/// IPv6 Segment Routing based on [`IETF DRAFT`].
 ///
-/// Routing Headers are defined in [IETF RFC 8200]. The Segment Routing
+/// Routing Headers are defined in [`IETF RFC 8200`]. The Segment Routing
 /// Header has a new Routing Type (suggested value 4) to be assigned by
 /// IANA.
 ///
@@ -52,48 +52,52 @@ use std::ptr::NonNull;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Next Header: 8-bit selector. Identifies the type of header
-/// immediately following the SRH.
+/// - *Next Header*:       8-bit selector. Identifies the type of header
+///                        immediately following the SRH.
 ///
-/// Hdr Ext Len: 8-bit unsigned integer, is the length of the SRH
-/// header in 8-octet units, not including the first 8 octets.
+/// - *Hdr Ext Len*:       8-bit unsigned integer, is the length of the SRH
+///                        header in 8-octet units, not including the first 8
+///                        octets.
 ///
-/// Routing Type: TBD, to be assigned by IANA (suggested value: 4).
+/// - *Routing Type*:      TBD, to be assigned by IANA (suggested value: 4).
 ///
-/// Segments Left: 8-bit unsigned integer Number of route segments
-/// remaining, i.e., number of explicitly listed intermediate nodes
-/// still to be visited before reaching the final destination.
+/// - *Segments Left*:     8-bit unsigned integer Number of route segments
+///                        remaining, i.e., number of explicitly listed
+///                        intermediate nodes still to be visited before
+///                        reaching the final destination.
 ///
-/// Last Entry: contains the index (zero based), in the Segment List,
-/// of the last element of the Segment List.
+/// - *Last Entry*:        Contains the index (zero based), in the Segment List,
+///                        of the last element of the Segment List.
 ///
-/// Flags: 8 bits of flags.  Following flags are defined:
+/// - *Flags*:             8 bits of flags. Following flags are defined:
 ///
-///      0 1 2 3 4 5 6 7
-///     +-+-+-+-+-+-+-+-+
-///     |U U U U U U U U|
-///     +-+-+-+-+-+-+-+-+
+///        0 1 2 3 4 5 6 7
+///       +-+-+-+-+-+-+-+-+
+///       |U U U U U U U U|
+///       +-+-+-+-+-+-+-+-+
 ///
-///    U: Unused and for future use.  MUST be 0 on transmission and
-///     ignored on receipt.
+///   - *U*:               Unused and for future use. *MUST* be 0 on transmission
+///                        and ignored on receipt.
 ///
-/// Tag: tag a packet as part of a class or group of packets, e.g.,
-/// packets sharing the same set of properties. When tag is not used
-/// at source it MUST be set to zero on transmission. When tag is not
-/// used during SRH Processing it SHOULD be ignored. The allocation
-/// and use of tag is outside the scope of this document.
+/// - *Tag*:               Tag a packet as part of a class or group of packets,
+///                        e.g., packets sharing the same set of properties.
+///                        When tag is not used at source it *MUST* be set to
+///                        zero on transmission. When tag is not used during SRH
+///                        Processing it *SHOULD* be ignored. The allocation and
+///                        use of tag is outside the scope of this document.
 ///
-/// Segment List[n]: 128 bit IPv6 addresses representing the nth
-/// segment in the Segment List.  The Segment List is encoded starting
-/// from the last segment of the SR Policy.  I.e., the first element
-/// of the segment list (Segment List [0]) contains the last segment
-/// of the SR Policy, the second element contains the penultimate
-/// segment of the SR Policy and so on.
+/// - *Segment List\[n]*:  128 bit IPv6 addresses representing the nth
+///                        segment in the Segment List.  The Segment List is
+///                        encoded starting from the last segment of the SR
+///                        Policy, i.e., the first element of the segment list
+///                        (Segment List \[0]) contains the last segment of the
+///                        SR Policy, the second element contains the
+///                        penultimate segment of the SR Policy and so on.
 ///
 /// Type Length Value (TLV) are described in Section 2.1.
 ///
-/// [IETF Draft]: https://tools.ietf.org/html/draft-ietf-6man-segment-routing-header-26#section-2
-/// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-4.4
+/// [`IETF Draft`]: https://tools.ietf.org/html/draft-ietf-6man-segment-routing-header-26#section-2
+/// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-4.4
 #[derive(Clone)]
 pub struct SegmentRouting<E: Ipv6Packet> {
     envelope: CondRc<E>,
@@ -392,14 +396,14 @@ impl<E: Ipv6Packet> IpPacket for SegmentRouting<E> {
 
     /// Returns the pseudo header.
     ///
-    /// Based on [IETF RFC 8200], if the IPv6 packet contains a Routing
+    /// Based on [`IETF RFC 8200`], if the IPv6 packet contains a Routing
     /// header, the Destination Address used in the pseudo-header is that
     /// of the final destination. At the originating node, that address will
     /// be in the last element of the Routing header; at the recipient(s),
     /// that address will be in the Destination Address field of the IPv6
     /// header.
     ///
-    /// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-8.1
+    /// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-8.1
     #[inline]
     fn pseudo_header(&self, packet_len: u16, protocol: ProtocolNumber) -> PseudoHeader {
         let dst = match self.dst() {
@@ -475,7 +479,9 @@ impl Default for SegmentRoutingHeader {
 
 impl Header for SegmentRoutingHeader {}
 
+/// IPv6 SRH packet as byte-array.
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const SRH_PACKET: [u8; 170] = [
 // ethernet header

--- a/core/src/packets/mod.rs
+++ b/core/src/packets/mod.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Common behaviors for all packet types and their associated headers.
+
 pub mod checksum;
 mod ethernet;
 pub mod icmp;
@@ -120,7 +122,7 @@ pub trait Packet: Clone {
         T::do_parse(self)
     }
 
-    // the public `parse::<T>` delegates to this function.
+    /// The public `parse::<T>` delegates to this function.
     #[doc(hidden)]
     fn do_parse(envelope: Self::Envelope) -> Result<Self>
     where
@@ -147,7 +149,7 @@ pub trait Packet: Clone {
         T::do_push(self)
     }
 
-    // the public `push::<T>` delegates to this function.
+    /// The public `push::<T>` delegates to this function.
     #[doc(hidden)]
     fn do_push(envelope: Self::Envelope) -> Result<Self>
     where
@@ -201,6 +203,7 @@ impl<T: Packet + fmt::Debug> fmt::Debug for Immutable<'_, T> {
 }
 
 impl<T: Packet> Immutable<'_, T> {
+    /// Creates a new immutable smart pointer to a packet.
     pub fn new(value: T) -> Self {
         Immutable {
             value,
@@ -230,11 +233,13 @@ pub(crate) enum CondRc<T: Packet> {
 }
 
 impl<T: Packet> CondRc<T> {
-    pub fn new(value: T) -> Self {
+    /// Creates a conditional reference to a packet counted smart pointer.
+    pub(crate) fn new(value: T) -> Self {
         CondRc::Raw(value)
     }
 
-    pub fn into_owned(self) -> T {
+    /// Consumes the CondRc and returns the packet of type T.
+    pub(crate) fn into_owned(self) -> T {
         match self {
             CondRc::Raw(value) => value,
             // because this fn requires ownership move, it should
@@ -281,6 +286,7 @@ impl<T: Packet> DerefMut for CondRc<T> {
 pub struct ParseError(String);
 
 impl ParseError {
+    /// Creates a new `ParseError` with a message.
     pub fn new(msg: &str) -> ParseError {
         ParseError(msg.into())
     }

--- a/core/src/packets/tcp.rs
+++ b/core/src/packets/tcp.rs
@@ -33,7 +33,7 @@ const RST: u8 = 0b0000_0100;
 const SYN: u8 = 0b0000_0010;
 const FIN: u8 = 0b0000_0001;
 
-/// Transmission Control Protocol packet based on [IETF RFC 793].
+/// Transmission Control Protocol packet based on [`IETF RFC 793`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -57,62 +57,62 @@ const FIN: u8 = 0b0000_0001;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Source Port:  16 bits
-///     The source port number.
+/// - *Source Port*: (16 bits)
+///      The source port number.
 ///
-/// Destination Port:  16 bits
-///     The destination port number.
+/// - *Destination Port*: (16 bits)
+///      The destination port number.
 ///
-/// Sequence Number:  32 bits
-///     The sequence number of the first data octet in this segment (except
-///     when SYN is present). If SYN is present the sequence number is the
-///     initial sequence number (ISN) and the first data octet is ISN+1.
+/// - *Sequence Number*: (32 bits)
+///      The sequence number of the first data octet in this segment (except
+///      when SYN is present). If SYN is present the sequence number is the
+///      initial sequence number (ISN) and the first data octet is ISN+1.
 ///
-/// Acknowledgment Number:  32 bits
-///     If the ACK control bit is set this field contains the value of the
-///     next sequence number the sender of the segment is expecting to
-///     receive.  Once a connection is established this is always sent.
+/// - *Acknowledgment Number*: (32 bits)
+///      If the ACK control bit is set this field contains the value of the
+///      next sequence number the sender of the segment is expecting to
+///      receive.  Once a connection is established this is always sent.
 ///
-/// Data Offset:  4 bits
-///     The number of 32 bit words in the TCP Header.  This indicates where
-///     the data begins.  The TCP header (even one including options) is an
-///     integral number of 32 bits long.
+/// - *Data Offset*: (4 bits)
+///      The number of 32 bit words in the TCP Header.  This indicates where
+///      the data begins.  The TCP header (even one including options) is an
+///      integral number of 32 bits long.
 ///
-/// Control Bits:  9 bits (from left to right):
-///     NS:   ECN-nonce nonce sum [IETF RFC 3540]
-///     CWR:  Congestion Window Reduced flag [IETF RFC 3168]
-///     ECE:  ECN-Echo flag [IETF RFC 3168]
-///     URG:  Urgent Pointer field significant
-///     ACK:  Acknowledgment field significant
-///     PSH:  Push Function
-///     RST:  Reset the connection
-///     SYN:  Synchronize sequence numbers
-///     FIN:  No more data from sender
+/// - *Control Bits*: (9 bits) [from left to right]
+///      - NS:   ECN-nonce nonce sum [`IETF RFC 3540`]
+///      - CWR:  Congestion Window Reduced flag [`IETF RFC 3168`]
+///      - ECE:  ECN-Echo flag [`IETF RFC 3168`]
+///      - URG:  Urgent Pointer field significant
+///      - ACK:  Acknowledgment field significant
+///      - PSH:  Push Function
+///      - RST:  Reset the connection
+///      - SYN:  Synchronize sequence numbers
+///      - FIN:  No more data from sender
 ///
-/// Window:  16 bits
-///     The number of data octets beginning with the one indicated in the
-///     acknowledgment field which the sender of this segment is willing to
-///     accept.
+/// - *Window*: (16 bits)
+///      The number of data octets beginning with the one indicated in the
+///      acknowledgment field which the sender of this segment is willing to
+///      accept.
 ///
-/// Checksum:  16 bits
-///     The checksum field is the 16 bit one's complement of the one's
-///     complement sum of all 16 bit words in the header and text.
+/// - *Checksum*: (16 bits)
+///      The checksum field is the 16 bit one's complement of the one's
+///      complement sum of all 16 bit words in the header and text.
 ///
-/// Urgent Pointer:  16 bits
-///     This field communicates the current value of the urgent pointer as a
-///     positive offset from the sequence number in this segment.  The
-///     urgent pointer points to the sequence number of the octet following
-///     the urgent data.  This field is only be interpreted in segments with
-///     the URG control bit set.
+/// - *Urgent Pointer*: (16 bits)
+///      This field communicates the current value of the urgent pointer as a
+///      positive offset from the sequence number in this segment.  The
+///      urgent pointer points to the sequence number of the octet following
+///      the urgent data.  This field is only be interpreted in segments with
+///      the URG control bit set.
 ///
-/// Options:  variable
+/// - *Options*: (variable)
 ///     Options may occupy space at the end of the TCP header and are a
 ///     multiple of 8 bits in length.  All options are included in the
 ///     checksum.
 ///
-/// [IETF RFC 793]: https://tools.ietf.org/html/rfc793#section-3.1
-/// [IETF RFC 3540]: https://tools.ietf.org/html/rfc3540
-/// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
+/// [`IETF RFC 793`]: https://tools.ietf.org/html/rfc793#section-3.1
+/// [`IETF RFC 3540`]: https://tools.ietf.org/html/rfc3540
+/// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
 #[derive(Clone)]
 pub struct Tcp<E: IpPacket> {
     envelope: CondRc<E>,
@@ -601,10 +601,12 @@ impl Default for TcpHeader {
 
 impl Header for TcpHeader {}
 
+/// IPv4 TCP packet as byte-array.
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const TCP_PACKET: [u8; 58] = [
-// ethernet header
+// Ethernet header
     0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
     0x08, 0x00,

--- a/core/src/packets/udp.rs
+++ b/core/src/packets/udp.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::net::IpAddr;
 use std::ptr::NonNull;
 
-/// User Datagram Protocol packet based on [IETF RFC 768].
+/// User Datagram Protocol packet based on [`IETF RFC 768`].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -37,34 +37,38 @@ use std::ptr::NonNull;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// Source Port is an optional field, when meaningful, it indicates the port
-/// of the sending  process,  and may be assumed  to be the port  to which a
-/// reply should  be addressed  in the absence of any other information.  If
-/// not used, a value of zero is inserted.
+/// - *Source Port*: (16 bits)
+///      An  optional field that, when meaningful, indicates the port
+///      of the sending  process, and may be assumed to be the port to which a
+///      reply should be addressed in the absence of any other information. If
+///      not used, a value of zero is inserted.
 ///
-/// Destination  Port has a meaning  within  the  context  of  a  particular
-/// internet destination address.
+/// - *Destination Port*: (16 bits)
+///      Has a meaning  within the context of a particular Internet
+///      destination address.
 ///
-/// Length  is the length  in octets  of this user datagram  including  this
-/// header  and the data.   (This  means  the minimum value of the length is
-/// eight.)
+/// - *Length*: (16 bits)
+///      The length  in octets of this user datagram including its
+///      header and the data. (This  means the minimum value of the length is
+///      eight.)
 ///
-/// Checksum is the 16-bit one's complement of the one's complement sum of a
-/// pseudo header of information from the IP header, the UDP header, and the
-/// data,  padded  with zero octets  at the end (if  necessary)  to  make  a
-/// multiple of two octets.
+/// - *Checksum*: (16 bits)
+///      The 16-bit one's complement of the one's complement sum of a
+///      pseudo header of information from the IP header, the UDP header, and
+///      the data, padded with zero octets at the end (if necessary) to make a
+///      multiple of two octets.
 ///
-/// The pseudo  header  conceptually prefixed to the UDP header contains the
-/// source  address,  the destination  address,  the protocol,  and the  UDP
-/// length.   This information gives protection against misrouted datagrams.
-/// This checksum procedure is the same as is used in TCP.
+///      The pseudo  header conceptually prefixed to the UDP header contains the
+///      source address,  the destination address, the protocol, and the UDP
+///      length. This information gives protection against misrouted datagrams.
+///      This checksum procedure is the same as is used in TCP.
 ///
-/// If the computed  checksum  is zero,  it is transmitted  as all ones (the
-/// equivalent  in one's complement  arithmetic).   An all zero  transmitted
-/// checksum  value means that the transmitter  generated  no checksum  (for
-/// debugging or for higher level protocols that don't care).
+///      If the computed  checksum  is zero,  it is transmitted  as all ones (the
+///      equivalent  in one's complement  arithmetic).   An all zero  transmitted
+///      checksum  value means that the transmitter  generated  no checksum  (for
+///      debugging or for higher level protocols that don't care).
 ///
-/// [IETF RFC 768]: https://tools.ietf.org/html/rfc768
+/// [`IETF RFC 768`]: https://tools.ietf.org/html/rfc768
 #[derive(Clone)]
 pub struct Udp<E: IpPacket> {
     envelope: CondRc<E>,
@@ -309,7 +313,9 @@ pub struct UdpHeader {
 
 impl Header for UdpHeader {}
 
+/// IPv4 UDP packet as byte-array.
 #[cfg(any(test, feature = "testils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 #[rustfmt::skip]
 pub const UDP_PACKET: [u8; 52] = [
 // ethernet header

--- a/core/src/testils/mod.rs
+++ b/core/src/testils/mod.rs
@@ -16,13 +16,18 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Utilities for unit tests and benchmarks.
+
 pub mod criterion;
 mod packet;
 pub mod proptest;
 mod rvg;
 
+/// Hand-crafted packet byte-arrays for testing and running examples.
 pub mod byte_arrays {
     pub use crate::packets::icmp::v4::ICMPV4_PACKET;
+    pub use crate::packets::icmp::v6::ndp::ROUTER_ADVERT_PACKET;
+    pub use crate::packets::icmp::v6::ndp::ROUTER_SOLICIT_PACKET;
     pub use crate::packets::icmp::v6::ICMPV6_PACKET;
     pub use crate::packets::ip::v6::{IPV6_PACKET, SRH_PACKET};
     pub use crate::packets::TCP_PACKET;
@@ -49,6 +54,7 @@ pub fn cargo_test_init() {
 
 /// A handle that keeps the mempool in scope for the duration of the test. It
 /// will unset the thread-bound mempool on drop.
+#[derive(Debug)]
 pub struct MempoolGuard {
     #[allow(dead_code)]
     inner: Mempool,

--- a/core/src/testils/packet.rs
+++ b/core/src/testils/packet.rs
@@ -20,44 +20,55 @@ use crate::packets::ip::v4::Ipv4;
 use crate::packets::ip::v6::{Ipv6, SegmentRouting};
 use crate::packets::{Ethernet, Packet, Tcp, Udp};
 
-/// `Packet` extension trait.
+/// [`Packet`] extension trait.
 ///
-/// Methods for packet conversion that make testing less verbose. Does not
-/// guarantee that the result of the conversion will be a valid packet,
+/// Helper methods for packet conversion that make testing less verbose. Does
+/// not guarantee that the result of the conversion will be a valid packet,
 /// and will panic if the conversion fails.
+///
+/// [`Packet`]: crate::packets::Packet
 pub trait PacketExt: Packet + Sized {
+    /// Converts the packet into an Ethernet packet.
     fn into_eth(self) -> Ethernet {
         self.reset().parse::<Ethernet>().unwrap()
     }
 
+    /// Converts the packet into an IPv4 packet.
     fn into_v4(self) -> Ipv4 {
         self.into_eth().parse::<Ipv4>().unwrap()
     }
 
+    /// Converts the packet into an TCP packet inside IPv4.
     fn into_v4_tcp(self) -> Tcp<Ipv4> {
         self.into_v4().parse::<Tcp<Ipv4>>().unwrap()
     }
 
+    /// Converts the packet into an UDP packet inside IPv4.
     fn into_v4_udp(self) -> Udp<Ipv4> {
         self.into_v4().parse::<Udp<Ipv4>>().unwrap()
     }
 
+    /// Converts the packet into an IPv6 packet.
     fn into_v6(self) -> Ipv6 {
         self.into_eth().parse::<Ipv6>().unwrap()
     }
 
+    /// Converts the packet into an TCP packet inside IPv6.
     fn into_v6_tcp(self) -> Tcp<Ipv6> {
         self.into_v6().parse::<Tcp<Ipv6>>().unwrap()
     }
 
+    /// Converts the packet into an UDP packet inside IPv6.
     fn into_v6_udp(self) -> Udp<Ipv6> {
         self.into_v6().parse::<Udp<Ipv6>>().unwrap()
     }
 
+    /// Converts the packet into an IPv6 packet with a SRH extension.
     fn into_sr(self) -> SegmentRouting<Ipv6> {
         self.into_v6().parse::<SegmentRouting<Ipv6>>().unwrap()
     }
 
+    /// Converts the packet into an TCP packet inside IPv6 with a SRH extension.
     fn into_sr_tcp(self) -> Tcp<SegmentRouting<Ipv6>> {
         self.into_sr().parse::<Tcp<SegmentRouting<Ipv6>>>().unwrap()
     }

--- a/core/src/testils/packet.rs
+++ b/core/src/testils/packet.rs
@@ -38,12 +38,12 @@ pub trait PacketExt: Packet + Sized {
         self.into_eth().parse::<Ipv4>().unwrap()
     }
 
-    /// Converts the packet into an TCP packet inside IPv4.
+    /// Converts the packet into a TCP packet inside IPv4.
     fn into_v4_tcp(self) -> Tcp<Ipv4> {
         self.into_v4().parse::<Tcp<Ipv4>>().unwrap()
     }
 
-    /// Converts the packet into an UDP packet inside IPv4.
+    /// Converts the packet into a UDP packet inside IPv4.
     fn into_v4_udp(self) -> Udp<Ipv4> {
         self.into_v4().parse::<Udp<Ipv4>>().unwrap()
     }
@@ -53,12 +53,12 @@ pub trait PacketExt: Packet + Sized {
         self.into_eth().parse::<Ipv6>().unwrap()
     }
 
-    /// Converts the packet into an TCP packet inside IPv6.
+    /// Converts the packet into a TCP packet inside IPv6.
     fn into_v6_tcp(self) -> Tcp<Ipv6> {
         self.into_v6().parse::<Tcp<Ipv6>>().unwrap()
     }
 
-    /// Converts the packet into an UDP packet inside IPv6.
+    /// Converts the packet into a UDP packet inside IPv6.
     fn into_v6_udp(self) -> Udp<Ipv6> {
         self.into_v6().parse::<Udp<Ipv6>>().unwrap()
     }
@@ -68,7 +68,7 @@ pub trait PacketExt: Packet + Sized {
         self.into_v6().parse::<SegmentRouting<Ipv6>>().unwrap()
     }
 
-    /// Converts the packet into an TCP packet inside IPv6 with a SRH extension.
+    /// Converts the packet into a TCP packet inside IPv6 with a SRH extension.
     fn into_sr_tcp(self) -> Tcp<SegmentRouting<Ipv6>> {
         self.into_sr().parse::<Tcp<SegmentRouting<Ipv6>>>().unwrap()
     }

--- a/core/src/testils/proptest/mod.rs
+++ b/core/src/testils/proptest/mod.rs
@@ -16,6 +16,13 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+//! Defines extended [`proptest`] [`Arbitrary`] traits and [`Strategies`] for
+//! packet generation and manipulation for testing and benchmarking purposes.
+//!
+//! [`proptest`]: https://github.com/altsysrq/proptest
+//! [`Arbitrary`]: https://docs.rs/proptest/*/proptest/arbitrary/index.html
+//! [`Strategies`]: https://docs.rs/proptest/*/proptest/strategy/trait.Strategy.html
+
 mod arbitrary;
 mod strategy;
 

--- a/core/src/testils/proptest/strategy.rs
+++ b/core/src/testils/proptest/strategy.rs
@@ -16,7 +16,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-//! proptest strategies
+//! Proptest strategies.
 
 use crate::net::MacAddr;
 use crate::packets::ip::v4::Ipv4;
@@ -36,12 +36,13 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// Enumeration of settable packet fields.
 #[allow(non_camel_case_types)]
+#[allow(missing_docs)]
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub enum field {
-    // ethernet
+    // Ethernet
     eth_src,
     eth_dst,
-    // ipv4
+    // IPv4
     ipv4_src,
     ipv4_dst,
     ipv4_dscp,
@@ -51,18 +52,18 @@ pub enum field {
     ipv4_more_fragments,
     ipv4_fragment_offset,
     ipv4_ttl,
-    // ipv6
+    // IPv6
     ipv6_src,
     ipv6_dst,
     ipv6_dscp,
     ipv6_ecn,
     ipv6_flow_label,
     ipv6_hop_limit,
-    // segment routing
+    // IPv6 Segment Routing
     sr_segments,
     sr_segments_left,
     sr_tag,
-    // tcp
+    // TCP
     tcp_src_port,
     tcp_dst_port,
     tcp_seq_no,
@@ -78,7 +79,7 @@ pub enum field {
     tcp_rst,
     tcp_syn,
     tcp_fin,
-    // udp
+    // UDP
     udp_src_port,
     udp_dst_port,
 }
@@ -100,9 +101,12 @@ pub enum field {
 ///
 /// When converting default value to proptest strategy, if the type of the
 /// value does not match the field type, the conversion will `panic`.
+#[derive(Debug)]
 pub struct StrategyMap(HashMap<field, Box<dyn Any>>);
 
 impl StrategyMap {
+    /// Creates a new strategy mapping from a hashmap of fields to possible
+    /// values.
     pub fn new(inner: HashMap<field, Box<dyn Any>>) -> Self {
         StrategyMap(inner)
     }

--- a/core/src/testils/rvg.rs
+++ b/core/src/testils/rvg.rs
@@ -20,23 +20,23 @@ use proptest::collection::vec;
 use proptest::strategy::{Strategy, ValueTree};
 use proptest::test_runner::{Config, TestRunner};
 
-/// Random value generator (RNG), which, given proptest strategies, will to
+/// A random value generator (RVG), which, given proptest strategies, will to
 /// generate random values based on those strategies.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Rvg {
     runner: TestRunner,
 }
 
 impl Rvg {
-    /// Create a new instance of the RVG with the default RNG.
+    /// Creates a new RVG with the default RNG (random number generator).
     pub fn new() -> Self {
         Rvg {
             runner: TestRunner::new(Config::default()),
         }
     }
 
-    /// Create a new instance of the RVG with a deterministic RNG,
-    /// using the same seed across test runs.
+    /// Creates a new RVG with a deterministic RNG
+    /// (random number generator), using the same seed across test runs.
     pub fn deterministic() -> Self {
         Rvg {
             runner: TestRunner::deterministic(),

--- a/examples/kni/Cargo.toml
+++ b/examples/kni/Cargo.toml
@@ -3,12 +3,12 @@ name = "kni"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "Kernel NIC interface example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+Kernel NIC interface example.
+"""
 
 [[bin]]
 name = "kni"

--- a/examples/kni/README.md
+++ b/examples/kni/README.md
@@ -35,7 +35,7 @@ $ ip link
     link/ether ba:dc:af:eb:ee:f1 brd ff:ff:ff:ff:ff:ff
 ```
 
-Kernel can assign an IP address to the device and bring the link up, at which point the kernel and the application can forward each other packets.
+The kernel can assign an IP address to the device and bring the link up, at which point the kernel and the application can forward each other packets.
 
 ```
 $ sudo ip addr add dev kni0 10.0.2.16/24

--- a/examples/nat64/Cargo.toml
+++ b/examples/nat64/Cargo.toml
@@ -3,12 +3,12 @@ name = "nat64"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "IPv6 to IPv4 NAT gateway example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+IPv6 to IPv4 NAT gateway example.
+"""
 
 [[bin]]
 name = "nat64"

--- a/examples/ping4d/Cargo.toml
+++ b/examples/ping4d/Cargo.toml
@@ -3,12 +3,12 @@ name = "ping4d"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "Ping4 daemon example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+Ping4 daemon example.
+"""
 
 [[bin]]
 name = "ping4d"

--- a/examples/pktdump/Cargo.toml
+++ b/examples/pktdump/Cargo.toml
@@ -3,12 +3,12 @@ name = "pktdump"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "Packet dump example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+Packet dump example.
+"""
 
 [[bin]]
 name = "pktdump"

--- a/examples/signals/Cargo.toml
+++ b/examples/signals/Cargo.toml
@@ -3,12 +3,12 @@ name = "signals"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "Linux signal handling example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+Linux signal handling example.
+"""
 
 [[bin]]
 name = "signals"

--- a/examples/skeleton/Cargo.toml
+++ b/examples/skeleton/Cargo.toml
@@ -3,12 +3,12 @@ name = "skeleton"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "Base skeleton example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+Base skeleton example.
+"""
 
 [[bin]]
 name = "skeleton"

--- a/examples/syn-flood/Cargo.toml
+++ b/examples/syn-flood/Cargo.toml
@@ -3,12 +3,12 @@ name = "syn-flood"
 version = "0.1.0"
 authors = ["Capsule Developers <occam_engineering@comcast.com>"]
 license = "Apache-2.0"
-keywords = []
-publish = false
 edition = "2018"
-description = "TCP SYN flood example"
+publish = false
 readme = "README.md"
-categories = []
+description = """
+TCP SYN flood example.
+"""
 
 [[bin]]
 name = "synflood"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,22 +1,21 @@
 [package]
 name = "capsule-ffi"
-version = "18.11.2"
-authors = ["Capsule Developers <occam_engineering@comcast.com>"]
+version = "18.11.6"
+authors = ["Capsule Developers <capsule-dev@googlegroups.com>"]
 license = "Apache-2.0"
-keywords = []
 edition = "2018"
 build = "build.rs"
 links = "dpdk"
-description = "Capsule FFI bindings for native libraries"
-readme = "../README.md"
-categories = []
+publish = false
+description = """
+Capsule FFI bindings for native libraries.
+"""
 
 [lib]
 name = "capsule_ffi"
 doctest = false
 
 [build-dependencies]
-# must be pinned to 0.51.1 revision exactly
-bindgen = "0.51.1"
+bindgen = "0.53"
 cc = "1.0"
 libc = "0.2"

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -16,8 +16,6 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-use bindgen;
-use cc;
 use std::env;
 use std::path::{Path, PathBuf};
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "capsule-macros"
 version = "0.1.0"
-authors = ["Capsule Developers <occam_engineering@comcast.com>"]
+authors = ["Capsule Developers <capsule-dev@googlegroups.com>"]
 license = "Apache-2.0"
-keywords = []
 edition = "2018"
-description = "Capsule procedural macros"
-categories = []
+publish = false
+description = """
+Capsule procedural macros.
+"""
 
 [lib]
 name = "capsule_macros"

--- a/macros/src/derive_packet.rs
+++ b/macros/src/derive_packet.rs
@@ -18,7 +18,6 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn;
 
 pub fn gen_icmpv6(input: syn::DeriveInput) -> TokenStream {
     let name = input.ident;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -25,7 +25,9 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{self, parse_macro_input};
 
-// Custom derive macro for SizeOf trait.
+/// Derive macro for [`SizeOf`].
+///
+/// [`SizeOf`]: crate::SizeOf
 #[proc_macro_derive(SizeOf)]
 pub fn derive_size_of(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
@@ -43,16 +45,26 @@ pub fn derive_size_of(input: TokenStream) -> TokenStream {
     expanded.into()
 }
 
-// Custom-derive macro implementation for `Icmpv4Packet`
+/// Derive macro for [`Icmpv4Packet`].
+///
+/// Also derives the associated [`Packet`] implementation.
+///
+/// [`Packet`]: crate::packets::Packet
+/// [`Icmpv4Packet`]: crate::packets::icmp::v4::Icmpv4Packet
 #[proc_macro_derive(Icmpv4Packet)]
-pub fn derive_icmpv6_packet(input: TokenStream) -> TokenStream {
+pub fn derive_icmpv4_packet(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     derive_packet::gen_icmpv4(input)
 }
 
-// Custom-derive macro implementation for `Icmpv6Packet`
+/// Derive macro for [`Icmpv6Packet`].
+///
+/// Also derives the associated [`Packet`] implementation.
+///
+/// [`Packet`]: crate::packets::Packet
+/// [`Icmpv6Packet`]: crate::packets::icmp::v6::Icmpv6Packet
 #[proc_macro_derive(Icmpv6Packet)]
-pub fn derive_icmpv4_packet(input: TokenStream) -> TokenStream {
+pub fn derive_icmpv6_packet(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     derive_packet::gen_icmpv6(input)
 }


### PR DESCRIPTION
- prep for doc features
- fix on macros crate for correct naming of derive functions
  (even though functionality correct)
- makefile doc updates for +nightly views
- integrate lib.rs docs w/ readme info
- cargo.toml cleanup
- update bindgen version gets us away from pin needs

### Needs

- [x] need @drunkirishcoder's readmes (sandbox and capsule) to fill out the main section. 