### PR TITLE
tidying up some todos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,12 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [stable, nightly]
+        # Allow failures on nightly, it's just informative
+        include:
+          - rust: stable
+            can-fail: false
+          - rust: nightly
+            can-fail: true
 
     container:
       image: getcapsule/sandbox
@@ -163,6 +169,7 @@ jobs:
         with:
           command: check
           args: --workspace --all-targets --all-features
+        continue-on-error: ${{ matrix.can-fail }}
 
       - name: slack-it
         uses: homoluctus/slatify@v2.1.2

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,6 +12,7 @@ Benchmarks for Capsule.
 [dev-dependencies]
 capsule = { version = "0.1", path = "../core", features = ["testils"] }
 criterion = "0.3"
+failure = "0.1"
 proptest = "0.9"
 
 [[bench]]

--- a/bench/combinators.rs
+++ b/bench/combinators.rs
@@ -21,8 +21,9 @@ use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::{Ethernet, Packet};
 use capsule::testils::criterion::BencherExt;
 use capsule::testils::proptest::*;
-use capsule::{compose, Mbuf, Result};
+use capsule::{compose, Mbuf};
 use criterion::{criterion_group, criterion_main, Criterion};
+use failure::Fallible;
 use proptest::prelude::*;
 use proptest::strategy;
 
@@ -85,7 +86,7 @@ fn map(batch: impl Batch<Item = Mbuf>) -> impl Batch<Item = Ethernet> {
     batch.map(|p| p.parse::<Ethernet>())
 }
 
-fn no_batch_map(mbuf: Mbuf) -> Result<Ethernet> {
+fn no_batch_map(mbuf: Mbuf) -> Fallible<Ethernet> {
     mbuf.parse::<Ethernet>()
 }
 
@@ -188,7 +189,7 @@ fn replace(batch: impl Batch<Item = Mbuf>) -> impl Batch<Item = Mbuf> {
     batch.replace(|_p| Mbuf::new())
 }
 
-fn no_batch_replace(_mbuf: Mbuf) -> Result<Mbuf> {
+fn no_batch_replace(_mbuf: Mbuf) -> Fallible<Mbuf> {
     Mbuf::new()
 }
 

--- a/bench/mbuf.rs
+++ b/bench/mbuf.rs
@@ -16,18 +16,19 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-use capsule::{Mbuf, Result};
+use capsule::Mbuf;
 use criterion::{criterion_group, criterion_main, Criterion};
+use failure::Fallible;
 
 const BATCH_SIZE: usize = 100;
 
-fn alloc() -> Result<Vec<Mbuf>> {
+fn alloc() -> Fallible<Vec<Mbuf>> {
     (0..BATCH_SIZE)
         .map(|_| Mbuf::new())
-        .collect::<Result<Vec<Mbuf>>>()
+        .collect::<Fallible<Vec<Mbuf>>>()
 }
 
-fn alloc_bulk() -> Result<Vec<Mbuf>> {
+fn alloc_bulk() -> Fallible<Vec<Mbuf>> {
     Mbuf::alloc_bulk(BATCH_SIZE)
 }
 

--- a/bench/packets.rs
+++ b/bench/packets.rs
@@ -22,8 +22,9 @@ use capsule::packets::{Ethernet, Packet, Udp};
 use capsule::testils::criterion::BencherExt;
 use capsule::testils::proptest::*;
 use capsule::testils::{PacketExt, Rvg};
-use capsule::{fieldmap, Mbuf, Result};
+use capsule::{fieldmap, Mbuf};
 use criterion::{criterion_group, criterion_main, Criterion};
+use failure::Fallible;
 use proptest::prelude::*;
 use std::net::Ipv6Addr;
 
@@ -227,7 +228,7 @@ fn multi_remove(c: &mut Criterion) {
     });
 }
 
-fn set_srh_segments(mut args: (SegmentRouting<Ipv6>, Vec<Ipv6Addr>)) -> Result<()> {
+fn set_srh_segments(mut args: (SegmentRouting<Ipv6>, Vec<Ipv6Addr>)) -> Fallible<()> {
     args.0.set_segments(&args.1)
 }
 

--- a/core/src/batch/filter_map.rs
+++ b/core/src/batch/filter_map.rs
@@ -18,7 +18,8 @@
 
 use super::{Batch, Disposition};
 use crate::packets::Packet;
-use crate::{Mbuf, Result};
+use crate::Mbuf;
+use failure::Fallible;
 
 /// The result of a [`filter_map`].
 ///
@@ -40,7 +41,7 @@ pub enum Either<T> {
 #[allow(missing_debug_implementations)]
 pub struct FilterMap<B: Batch, T: Packet, F>
 where
-    F: FnMut(B::Item) -> Result<Either<T>>,
+    F: FnMut(B::Item) -> Fallible<Either<T>>,
 {
     batch: B,
     f: F,
@@ -48,7 +49,7 @@ where
 
 impl<B: Batch, T: Packet, F> FilterMap<B, T, F>
 where
-    F: FnMut(B::Item) -> Result<Either<T>>,
+    F: FnMut(B::Item) -> Fallible<Either<T>>,
 {
     /// Creates a new `FilterMap` batch.
     #[inline]
@@ -59,7 +60,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for FilterMap<B, T, F>
 where
-    F: FnMut(B::Item) -> Result<Either<T>>,
+    F: FnMut(B::Item) -> Fallible<Either<T>>,
 {
     type Item = T;
 

--- a/core/src/batch/for_each.rs
+++ b/core/src/batch/for_each.rs
@@ -17,13 +17,13 @@
 */
 
 use super::{Batch, Disposition};
-use crate::Result;
+use failure::Fallible;
 
 /// A batch that calls a closure on packets in the underlying batch.
 #[allow(missing_debug_implementations)]
 pub struct ForEach<B: Batch, F>
 where
-    F: FnMut(&B::Item) -> Result<()>,
+    F: FnMut(&B::Item) -> Fallible<()>,
 {
     batch: B,
     f: F,
@@ -31,7 +31,7 @@ where
 
 impl<B: Batch, F> ForEach<B, F>
 where
-    F: FnMut(&B::Item) -> Result<()>,
+    F: FnMut(&B::Item) -> Fallible<()>,
 {
     /// Creates a new `ForEach` batch.
     #[inline]
@@ -42,7 +42,7 @@ where
 
 impl<B: Batch, F> Batch for ForEach<B, F>
 where
-    F: FnMut(&B::Item) -> Result<()>,
+    F: FnMut(&B::Item) -> Fallible<()>,
 {
     type Item = B::Item;
 

--- a/core/src/batch/map.rs
+++ b/core/src/batch/map.rs
@@ -18,7 +18,7 @@
 
 use super::{Batch, Disposition};
 use crate::packets::Packet;
-use crate::Result;
+use failure::Fallible;
 
 /// A batch that maps the packets of the underlying batch.
 ///
@@ -27,7 +27,7 @@ use crate::Result;
 #[allow(missing_debug_implementations)]
 pub struct Map<B: Batch, T: Packet, F>
 where
-    F: FnMut(B::Item) -> Result<T>,
+    F: FnMut(B::Item) -> Fallible<T>,
 {
     batch: B,
     f: F,
@@ -35,7 +35,7 @@ where
 
 impl<B: Batch, T: Packet, F> Map<B, T, F>
 where
-    F: FnMut(B::Item) -> Result<T>,
+    F: FnMut(B::Item) -> Fallible<T>,
 {
     /// Creates a new `Map` batch.
     #[inline]
@@ -46,7 +46,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for Map<B, T, F>
 where
-    F: FnMut(B::Item) -> Result<T>,
+    F: FnMut(B::Item) -> Fallible<T>,
 {
     type Item = T;
 

--- a/core/src/batch/mod.rs
+++ b/core/src/batch/mod.rs
@@ -43,8 +43,8 @@ pub use self::rxtx::*;
 pub use self::send::*;
 
 use crate::packets::Packet;
-use crate::{Mbuf, Result};
-use failure::Error;
+use crate::Mbuf;
+use failure::{Error, Fallible};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -210,7 +210,7 @@ pub trait Batch {
     #[inline]
     fn filter_map<T: Packet, F>(self, f: F) -> FilterMap<Self, T, F>
     where
-        F: FnMut(Self::Item) -> Result<Either<T>>,
+        F: FnMut(Self::Item) -> Fallible<Either<T>>,
         Self: Sized,
     {
         FilterMap::new(self, f)
@@ -228,7 +228,7 @@ pub trait Batch {
     #[inline]
     fn map<T: Packet, F>(self, f: F) -> Map<Self, T, F>
     where
-        F: FnMut(Self::Item) -> Result<T>,
+        F: FnMut(Self::Item) -> Fallible<T>,
         Self: Sized,
     {
         Map::new(self, f)
@@ -250,7 +250,7 @@ pub trait Batch {
     #[inline]
     fn for_each<F>(self, f: F) -> ForEach<Self, F>
     where
-        F: FnMut(&Self::Item) -> Result<()>,
+        F: FnMut(&Self::Item) -> Fallible<()>,
         Self: Sized,
     {
         ForEach::new(self, f)
@@ -355,7 +355,7 @@ pub trait Batch {
     /// });
     fn replace<T: Packet, F>(self, f: F) -> Replace<Self, T, F>
     where
-        F: FnMut(&Self::Item) -> Result<T>,
+        F: FnMut(&Self::Item) -> Fallible<T>,
         Self: Sized,
     {
         Replace::new(self, f)

--- a/core/src/batch/replace.rs
+++ b/core/src/batch/replace.rs
@@ -18,7 +18,7 @@
 
 use super::{Batch, Disposition};
 use crate::packets::Packet;
-use crate::Result;
+use failure::Fallible;
 
 /// A batch that replaces each packet of the batch with another packet.
 ///
@@ -28,7 +28,7 @@ use crate::Result;
 #[allow(missing_debug_implementations)]
 pub struct Replace<B: Batch, T: Packet, F>
 where
-    F: FnMut(&B::Item) -> Result<T>,
+    F: FnMut(&B::Item) -> Fallible<T>,
 {
     batch: B,
     f: F,
@@ -37,7 +37,7 @@ where
 
 impl<B: Batch, T: Packet, F> Replace<B, T, F>
 where
-    F: FnMut(&B::Item) -> Result<T>,
+    F: FnMut(&B::Item) -> Fallible<T>,
 {
     /// Creates a new `Replace` batch.
     #[inline]
@@ -52,7 +52,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for Replace<B, T, F>
 where
-    F: FnMut(&B::Item) -> Result<T>,
+    F: FnMut(&B::Item) -> Fallible<T>,
 {
     type Item = T;
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -47,8 +47,8 @@
 
 use crate::dpdk::CoreId;
 use crate::net::{Ipv4Cidr, Ipv6Cidr, MacAddr};
-use crate::Result;
 use clap::{clap_app, crate_version};
+use failure::Fallible;
 use regex::Regex;
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
@@ -58,7 +58,7 @@ use std::time::Duration;
 
 // make `CoreId` serde deserializable.
 impl<'de> Deserialize<'de> for CoreId {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -69,7 +69,7 @@ impl<'de> Deserialize<'de> for CoreId {
 
 // make `MacAddr` serde deserializable.
 impl<'de> Deserialize<'de> for MacAddr {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -80,7 +80,7 @@ impl<'de> Deserialize<'de> for MacAddr {
 
 // make `Ipv4Cidr` serde deserializable.
 impl<'de> Deserialize<'de> for Ipv4Cidr {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -91,7 +91,7 @@ impl<'de> Deserialize<'de> for Ipv4Cidr {
 
 // make `Ipv6Cidr` serde deserializable.
 impl<'de> Deserialize<'de> for Ipv6Cidr {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for Ipv6Cidr {
 }
 
 /// Deserializes a duration from seconds expressed as `u64`.
-pub fn duration_from_secs<'de, D>(deserializer: D) -> std::result::Result<Duration, D::Error>
+pub fn duration_from_secs<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -110,9 +110,7 @@ where
 }
 
 /// Deserializes an option of duration from seconds expressed as `u64`.
-pub fn duration_option_from_secs<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<Duration>, D::Error>
+pub fn duration_option_from_secs<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -414,7 +412,7 @@ impl fmt::Debug for PortConfig {
 /// ```
 /// home$ ./myapp -f config.toml
 /// ```
-pub fn load_config() -> Result<RuntimeConfig> {
+pub fn load_config() -> Fallible<RuntimeConfig> {
     let matches = clap_app!(capsule =>
         (version: crate_version!())
         (@arg file: -f --file +required +takes_value "configuration file")

--- a/core/src/dpdk/kni.rs
+++ b/core/src/dpdk/kni.rs
@@ -21,8 +21,8 @@ use crate::ffi::{self, AsStr, ToResult};
 #[cfg(feature = "metrics")]
 use crate::metrics::{labels, Counter, SINK};
 use crate::net::MacAddr;
-use crate::{debug, error, warn, Result};
-use failure::Fail;
+use crate::{debug, error, warn};
+use failure::{Fail, Fallible};
 use futures::{future, Future, StreamExt};
 use std::cmp;
 use std::mem;
@@ -279,12 +279,12 @@ impl Kni {
     }
 
     /// Takes ownership of the RX handle.
-    pub(crate) fn take_rx(&mut self) -> Result<KniRx> {
+    pub(crate) fn take_rx(&mut self) -> Fallible<KniRx> {
         self.rx.take().ok_or_else(|| KniError::NotAcquired.into())
     }
 
     /// Takes ownership of the TX handle.
-    pub(crate) fn take_tx(&mut self) -> Result<KniTx> {
+    pub(crate) fn take_tx(&mut self) -> Fallible<KniTx> {
         self.tx.take().ok_or_else(|| KniError::NotAcquired.into())
     }
 
@@ -378,7 +378,7 @@ impl<'a> KniBuilder<'a> {
         self
     }
 
-    pub(crate) fn finish(&mut self) -> Result<Kni> {
+    pub(crate) fn finish(&mut self) -> Fallible<Kni> {
         self.conf.mbuf_size = ffi::RTE_MBUF_DEFAULT_BUF_SIZE;
         self.ops.change_mtu = Some(change_mtu);
         self.ops.config_network_if = Some(config_network_if);
@@ -394,7 +394,7 @@ impl<'a> KniBuilder<'a> {
 }
 
 /// Initializes and preallocates the KNI subsystem.
-pub(crate) fn kni_init(max: usize) -> Result<()> {
+pub(crate) fn kni_init(max: usize) -> Fallible<()> {
     unsafe {
         ffi::rte_kni_init(max as raw::c_uint)
             .to_result()

--- a/core/src/dpdk/mempool.rs
+++ b/core/src/dpdk/mempool.rs
@@ -18,8 +18,8 @@
 
 use super::SocketId;
 use crate::ffi::{self, AsStr, ToCString, ToResult};
-use crate::{debug, info, Result};
-use failure::Fail;
+use crate::{debug, info};
+use failure::{Fail, Fallible};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fmt;
@@ -50,7 +50,7 @@ impl Mempool {
     /// # Errors
     ///
     /// If allocation fails, then `DpdkError` is returned.
-    pub(crate) fn new(capacity: usize, cache_size: usize, socket_id: SocketId) -> Result<Self> {
+    pub(crate) fn new(capacity: usize, cache_size: usize, socket_id: SocketId) -> Fallible<Self> {
         static MEMPOOL_COUNT: AtomicUsize = AtomicUsize::new(0);
         let n = MEMPOOL_COUNT.fetch_add(1, Ordering::Relaxed);
         let name = format!("mempool{}", n);
@@ -156,7 +156,7 @@ impl<'a> MempoolMap<'a> {
     /// # Errors
     ///
     /// If the value is not found, `MempoolNotFound` is returned.
-    pub(crate) fn get_raw(&mut self, socket_id: SocketId) -> Result<&mut ffi::rte_mempool> {
+    pub(crate) fn get_raw(&mut self, socket_id: SocketId) -> Fallible<&mut ffi::rte_mempool> {
         self.inner
             .get_mut(&socket_id)
             .ok_or_else(|| MempoolNotFound(socket_id).into())

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -33,10 +33,10 @@ pub use self::port::*;
 #[cfg(feature = "metrics")]
 pub(crate) use self::stats::*;
 
+use crate::debug;
 use crate::ffi::{self, AsStr, ToCString, ToResult};
 use crate::net::MacAddr;
-use crate::{debug, Result};
-use failure::Fail;
+use failure::{Fail, Fallible};
 use std::cell::Cell;
 use std::fmt;
 use std::mem;
@@ -148,7 +148,7 @@ impl CoreId {
     /// Sets the current thread's affinity to this core.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
-    pub(crate) fn set_thread_affinity(&self) -> Result<()> {
+    pub(crate) fn set_thread_affinity(&self) -> Fallible<()> {
         unsafe {
             // the two types that represent `cpu_set` have identical layout,
             // hence it is safe to transmute between them.
@@ -174,7 +174,7 @@ thread_local! {
 }
 
 /// Initializes the Environment Abstraction Layer (EAL).
-pub(crate) fn eal_init(args: Vec<String>) -> Result<()> {
+pub(crate) fn eal_init(args: Vec<String>) -> Fallible<()> {
     debug!(arguments=?args);
 
     let len = args.len() as raw::c_int;
@@ -191,7 +191,7 @@ pub(crate) fn eal_init(args: Vec<String>) -> Result<()> {
 }
 
 /// Cleans up the Environment Abstraction Layer (EAL).
-pub(crate) fn eal_cleanup() -> Result<()> {
+pub(crate) fn eal_cleanup() -> Fallible<()> {
     unsafe { ffi::rte_eal_cleanup().to_result().map(|_| ()) }
 }
 

--- a/core/src/dpdk/port.rs
+++ b/core/src/dpdk/port.rs
@@ -23,8 +23,8 @@ use crate::metrics::{labels, Counter, SINK};
 use crate::net::MacAddr;
 #[cfg(feature = "pcap-dump")]
 use crate::pcap;
-use crate::{debug, ensure, info, warn, Result};
-use failure::Fail;
+use crate::{debug, ensure, info, warn};
+use failure::{Fail, Fallible};
 use std::collections::HashMap;
 use std::fmt;
 use std::mem;
@@ -318,7 +318,7 @@ impl Port {
     /// # Errors
     ///
     /// If the port fails to start, `DpdkError` is returned.
-    pub(crate) fn start(&mut self) -> Result<()> {
+    pub(crate) fn start(&mut self) -> Fallible<()> {
         unsafe {
             ffi::rte_eth_dev_start(self.id.0).to_result()?;
         }
@@ -391,7 +391,7 @@ impl<'a> PortBuilder<'a> {
     /// # Errors
     ///
     /// If the device is not found, `DpdkError` is returned.
-    pub(crate) fn new(name: String, device: String) -> Result<Self> {
+    pub(crate) fn new(name: String, device: String) -> Fallible<Self> {
         let mut port_id = 0u16;
         unsafe {
             ffi::rte_eth_dev_get_port_by_name(device.clone().to_cstring().as_ptr(), &mut port_id)
@@ -427,7 +427,7 @@ impl<'a> PortBuilder<'a> {
     ///
     /// If either the maximum number of RX or TX queues is less than the
     /// number of cores assigned, `PortError` is returned.
-    pub(crate) fn cores(&mut self, cores: &[CoreId]) -> Result<&mut Self> {
+    pub(crate) fn cores(&mut self, cores: &[CoreId]) -> Fallible<&mut Self> {
         ensure!(!cores.is_empty(), PortError::CoreNotBound);
 
         let mut cores = cores.to_vec();
@@ -457,7 +457,7 @@ impl<'a> PortBuilder<'a> {
     /// # Errors
     ///
     /// If the adjustment failed, `DpdkError` is returned.
-    pub(crate) fn rx_tx_queue_capacity(&mut self, rxd: usize, txd: usize) -> Result<&mut Self> {
+    pub(crate) fn rx_tx_queue_capacity(&mut self, rxd: usize, txd: usize) -> Fallible<&mut Self> {
         let mut rxd2 = rxd as u16;
         let mut txd2 = txd as u16;
 
@@ -497,7 +497,7 @@ impl<'a> PortBuilder<'a> {
         promiscuous: bool,
         multicast: bool,
         with_kni: bool,
-    ) -> Result<Port> {
+    ) -> Fallible<Port> {
         let len = self.cores.len() as u16;
         let mut conf = ffi::rte_eth_conf::default();
 

--- a/core/src/dpdk/stats.rs
+++ b/core/src/dpdk/stats.rs
@@ -19,7 +19,7 @@
 use super::{Mempool, Port, PortId};
 use crate::ffi::{self, AsStr, ToResult};
 use crate::metrics::{labels, Key, Measurement};
-use crate::Result;
+use failure::Fallible;
 use std::ptr::NonNull;
 
 /// Port stats collector.
@@ -57,7 +57,7 @@ impl PortStats {
     }
 
     /// Collects the port stats tracked by DPDK.
-    pub(crate) fn collect(&self) -> Result<Vec<(Key, Measurement)>> {
+    pub(crate) fn collect(&self) -> Fallible<Vec<(Key, Measurement)>> {
         let mut stats = ffi::rte_eth_stats::default();
         unsafe {
             ffi::rte_eth_stats_get(self.id.raw(), &mut stats).to_result()?;

--- a/core/src/ffi.rs
+++ b/core/src/ffi.rs
@@ -19,7 +19,8 @@
 pub(crate) use capsule_ffi::*;
 
 use crate::dpdk::DpdkError;
-use crate::{warn, Result};
+use crate::warn;
+use failure::Fallible;
 use std::ffi::{CStr, CString};
 use std::os::raw;
 use std::ptr::NonNull;
@@ -76,14 +77,14 @@ impl ToCString for &str {
 pub(crate) trait ToResult {
     type Ok;
 
-    fn to_result(self) -> Result<Self::Ok>;
+    fn to_result(self) -> Fallible<Self::Ok>;
 }
 
 impl ToResult for raw::c_int {
     type Ok = u32;
 
     #[inline]
-    fn to_result(self) -> Result<Self::Ok> {
+    fn to_result(self) -> Fallible<Self::Ok> {
         match self {
             -1 => Err(DpdkError::new().into()),
             err if err < 0 => Err(DpdkError::new_with_errno(-err).into()),
@@ -96,7 +97,7 @@ impl<T> ToResult for *mut T {
     type Ok = NonNull<T>;
 
     #[inline]
-    fn to_result(self) -> Result<Self::Ok> {
+    fn to_result(self) -> Fallible<Self::Ok> {
         NonNull::new(self).ok_or_else(|| DpdkError::new().into())
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -136,6 +136,3 @@ pub use self::runtime::{Runtime, UnixSignal};
 #[cfg_attr(docsrs, doc(cfg(feature = "testils")))]
 pub use capsule_macros::{bench, test};
 pub use capsule_macros::{Icmpv4Packet, Icmpv6Packet, SizeOf};
-
-/// A type alias of `std:result::Result` for convenience.
-pub type Result<T> = std::result::Result<T, failure::Error>;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -77,8 +77,8 @@ pub(crate) use metrics_runtime::data::Counter;
 pub(crate) use metrics_runtime::Measurement;
 
 use crate::dpdk::{Mempool, MempoolStats, Port};
-use crate::{warn, Result};
-use failure::format_err;
+use crate::warn;
+use failure::{format_err, Fallible};
 use metrics_runtime::{Receiver, Sink};
 use once_cell::sync::{Lazy, OnceCell};
 
@@ -89,7 +89,7 @@ static RECEIVER: OnceCell<Receiver> = OnceCell::new();
 /// potentially fail, the `Lazy` convenience type is not safe.
 ///
 /// Also very important that `init` is not called twice.
-pub(crate) fn init() -> Result<()> {
+pub(crate) fn init() -> Fallible<()> {
     let receiver = Receiver::builder().build()?;
 
     RECEIVER

--- a/core/src/net/mac.rs
+++ b/core/src/net/mac.rs
@@ -67,7 +67,7 @@ pub struct MacParseError(String);
 impl FromStr for MacAddr {
     type Err = MacParseError;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let u8s = s
             .split(|c| c == ':' || c == '-')
             .map(|s| u8::from_str_radix(s, 16))

--- a/core/src/packets/checksum.rs
+++ b/core/src/packets/checksum.rs
@@ -20,7 +20,7 @@
 //! including calculation involving *pseudo headers*.
 
 use crate::packets::ip::{IpPacketError, ProtocolNumber};
-use crate::Result;
+use failure::Fallible;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::slice;
 
@@ -199,7 +199,7 @@ pub fn compute_with_ipaddr(
     old_checksum: u16,
     old_value: &IpAddr,
     new_value: &IpAddr,
-) -> Result<u16> {
+) -> Fallible<u16> {
     match (old_value, new_value) {
         (IpAddr::V4(old), IpAddr::V4(new)) => {
             let old: u32 = (*old).into();

--- a/core/src/packets/icmp/v4/echo_reply.rs
+++ b/core/src/packets/icmp/v4/echo_reply.rs
@@ -18,7 +18,8 @@
 
 use crate::packets::icmp::v4::{Icmpv4, Icmpv4Packet, Icmpv4Payload, Icmpv4Type, Icmpv4Types};
 use crate::packets::Packet;
-use crate::{Icmpv4Packet, Result, SizeOf};
+use crate::{Icmpv4Packet, SizeOf};
+use failure::Fallible;
 use std::fmt;
 
 /// Echo Reply Message defined in [`IETF RFC 792`].
@@ -42,7 +43,10 @@ use std::fmt;
 ///
 /// *Data*:             The data from the invoking Echo Request message.
 ///
+/// The fields are accessible through [`Icmpv4<EchoReply>`].
+///
 /// [`IETF RFC 792`]: https://tools.ietf.org/html/rfc792
+/// [`Icmpv4<EchoReply>`]: Icmpv4
 #[derive(Clone, Copy, Debug, Default, Icmpv4Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct EchoReply {
@@ -108,7 +112,7 @@ impl Icmpv4<EchoReply> {
 
     /// Sets the data.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.mbuf_mut().resize(offset, len)?;

--- a/core/src/packets/icmp/v4/echo_request.rs
+++ b/core/src/packets/icmp/v4/echo_request.rs
@@ -18,7 +18,8 @@
 
 use crate::packets::icmp::v4::{Icmpv4, Icmpv4Packet, Icmpv4Payload, Icmpv4Type, Icmpv4Types};
 use crate::packets::Packet;
-use crate::{Icmpv4Packet, Result, SizeOf};
+use crate::{Icmpv4Packet, SizeOf};
+use failure::Fallible;
 use std::fmt;
 
 /// Echo Request Message defined in [`IETF RFC 792`].
@@ -43,7 +44,10 @@ use std::fmt;
 ///
 /// *Data*:             Zero or more octets of arbitrary data.
 ///
+/// The fields are accessible through [`Icmpv4<EchoRequest>`].
+///
 /// [`IETF RFC 792`]: https://tools.ietf.org/html/rfc792
+/// [`Icmpv4<EchoRequest>`]: Icmpv4
 #[derive(Clone, Copy, Debug, Default, Icmpv4Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct EchoRequest {
@@ -109,7 +113,7 @@ impl Icmpv4<EchoRequest> {
 
     /// Sets the data.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.mbuf_mut().resize(offset, len)?;

--- a/core/src/packets/icmp/v6/echo_reply.rs
+++ b/core/src/packets/icmp/v6/echo_reply.rs
@@ -19,7 +19,8 @@
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
+use crate::{Icmpv6Packet, SizeOf};
+use failure::Fallible;
 use std::fmt;
 
 /// Echo Reply Message defined in [`IETF RFC 4443`].
@@ -43,7 +44,10 @@ use std::fmt;
 ///
 /// - *Data*:             The data from the invoking Echo Request message.
 ///
+/// The fields are accessible through [`Icmpv6<E, EchoReply>`].
+///
 /// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-4.2
+/// [`Icmpv6<E, EchoReply>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Default, SizeOf, Icmpv6Packet)]
 #[repr(C, packed)]
 pub struct EchoReply {
@@ -109,7 +113,7 @@ impl<E: Ipv6Packet> Icmpv6<E, EchoReply> {
 
     /// Sets the data.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.mbuf_mut().resize(offset, len)?;

--- a/core/src/packets/icmp/v6/echo_request.rs
+++ b/core/src/packets/icmp/v6/echo_request.rs
@@ -19,7 +19,8 @@
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
+use crate::{Icmpv6Packet, SizeOf};
+use failure::Fallible;
 use std::fmt;
 
 /// Echo Request Message defined in [`IETF RFC 4443`].
@@ -44,7 +45,10 @@ use std::fmt;
 ///
 /// - *Data*:             Zero or more octets of arbitrary data.
 ///
+/// The fields are accessible through [`Icmpv6<E, EchoRequest>`].
+///
 /// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-4.1
+/// [`Icmpv6<E, EchoRequest>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct EchoRequest {
@@ -110,7 +114,7 @@ impl<E: Ipv6Packet> Icmpv6<E, EchoRequest> {
 
     /// Sets the data.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.mbuf_mut().resize(offset, len)?;

--- a/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
@@ -20,8 +20,7 @@ use crate::packets::icmp::v6::ndp::NdpPayload;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
-
+use crate::{Icmpv6Packet, SizeOf};
 use std::fmt;
 use std::net::Ipv6Addr;
 
@@ -97,7 +96,10 @@ const O_FLAG: u8 = 0b0010_0000;
 ///                                 a unicast Neighbor Solicitation this option
 ///                                 *SHOULD* be included.
 ///
+/// The fields are accessible through [`Icmpv6<E, NeighborAdvertisement>`].
+///
 /// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.4
+/// [`Icmpv6<E, NeighborAdvertisement>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Icmpv6Packet, SizeOf)]
 #[repr(C)]
 pub struct NeighborAdvertisement {

--- a/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
@@ -20,7 +20,7 @@ use crate::packets::icmp::v6::ndp::NdpPayload;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
+use crate::{Icmpv6Packet, SizeOf};
 use std::fmt;
 use std::net::Ipv6Addr;
 
@@ -58,7 +58,10 @@ use std::net::Ipv6Addr;
 ///                                 multicast solicitations and *SHOULD* be
 ///                                 included in unicast solicitations.
 ///
+/// The fields are accessible through [`Icmpv6<E, NeighborSolicitation>`].
+///
 /// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.3
+/// [`Icmpv6<E, NeighborSolicitation>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Icmpv6Packet, SizeOf)]
 #[repr(C)]
 pub struct NeighborSolicitation {

--- a/core/src/packets/icmp/v6/ndp/options/mod.rs
+++ b/core/src/packets/icmp/v6/ndp/options/mod.rs
@@ -28,7 +28,8 @@ pub use self::mtu::*;
 pub use self::prefix_info::*;
 
 use crate::packets::ParseError;
-use crate::{Mbuf, Result};
+use crate::Mbuf;
+use failure::Fallible;
 use fallible_iterator::FallibleIterator;
 
 /// Source link-layer address option.
@@ -59,7 +60,7 @@ pub enum NdpOptions {
 /// Common behaviors shared by NDP options.
 pub trait NdpOption {
     #[doc(hidden)]
-    fn do_push(mbuf: &mut Mbuf) -> Result<Self>
+    fn do_push(mbuf: &mut Mbuf) -> Fallible<Self>
     where
         Self: Sized;
 }
@@ -82,7 +83,7 @@ impl FallibleIterator for NdpOptionsIterator<'_> {
     type Item = NdpOptions;
     type Error = failure::Error;
 
-    fn next(&mut self) -> std::result::Result<Option<Self::Item>, Self::Error> {
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
         let buffer_len = self.mbuf.data_len();
 
         if self.offset <= buffer_len {

--- a/core/src/packets/icmp/v6/ndp/options/mtu.rs
+++ b/core/src/packets/icmp/v6/ndp/options/mtu.rs
@@ -18,7 +18,8 @@
 
 use super::{NdpOption, MTU};
 use crate::packets::ParseError;
-use crate::{ensure, Mbuf, Result, SizeOf};
+use crate::{ensure, Mbuf, SizeOf};
+use failure::Fallible;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -54,7 +55,7 @@ pub struct Mtu {
 impl Mtu {
     /// Parses the MTU option from the message buffer at offset.
     #[inline]
-    pub fn parse(mbuf: &Mbuf, offset: usize) -> Result<Mtu> {
+    pub fn parse(mbuf: &Mbuf, offset: usize) -> Fallible<Mtu> {
         let fields = mbuf.read_data::<MtuFields>(offset)?;
 
         ensure!(
@@ -115,7 +116,7 @@ impl fmt::Debug for Mtu {
 
 impl NdpOption for Mtu {
     #[inline]
-    fn do_push(mbuf: &mut Mbuf) -> Result<Self>
+    fn do_push(mbuf: &mut Mbuf) -> Fallible<Self>
     where
         Self: Sized,
     {

--- a/core/src/packets/icmp/v6/ndp/options/prefix_info.rs
+++ b/core/src/packets/icmp/v6/ndp/options/prefix_info.rs
@@ -18,7 +18,8 @@
 
 use super::{NdpOption, PREFIX_INFORMATION};
 use crate::packets::ParseError;
-use crate::{ensure, Mbuf, Result, SizeOf};
+use crate::{ensure, Mbuf, SizeOf};
+use failure::Fallible;
 use std::fmt;
 use std::net::Ipv6Addr;
 use std::ptr::NonNull;
@@ -117,7 +118,7 @@ pub struct PrefixInformation {
 impl PrefixInformation {
     /// Parses the prefix information option from the message buffer at offset.
     #[inline]
-    pub fn parse(mbuf: &Mbuf, offset: usize) -> Result<PrefixInformation> {
+    pub fn parse(mbuf: &Mbuf, offset: usize) -> Fallible<PrefixInformation> {
         let fields = mbuf.read_data::<PrefixInformationFields>(offset)?;
 
         ensure!(
@@ -262,7 +263,7 @@ impl fmt::Debug for PrefixInformation {
 
 impl NdpOption for PrefixInformation {
     #[inline]
-    fn do_push(mbuf: &mut Mbuf) -> Result<Self>
+    fn do_push(mbuf: &mut Mbuf) -> Fallible<Self>
     where
         Self: Sized,
     {

--- a/core/src/packets/icmp/v6/ndp/router_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/router_solicit.rs
@@ -20,7 +20,7 @@ use crate::packets::icmp::v6::ndp::NdpPayload;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
+use crate::{Icmpv6Packet, SizeOf};
 use std::fmt;
 
 /// Router Solicitation Message defined in [`IETF RFC 4861`].
@@ -49,11 +49,14 @@ use std::fmt;
 ///                                 Otherwise, it *SHOULD* be included on link
 ///                                 layers that have addresses.
 ///
+/// The fields are accessible through [`Icmpv6<E, RouterSolicitation>`].
+///
 /// [`IETF RFC 4861`]: https://tools.ietf.org/html/rfc4861#section-4.1
+/// [`Icmpv6<E, RouterSolicitation>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct RouterSolicitation {
-    reserved: u32,
+    _reserved: u32,
 }
 
 impl Icmpv6Payload for RouterSolicitation {
@@ -67,13 +70,6 @@ impl NdpPayload for RouterSolicitation {}
 
 impl<E: Ipv6Packet> Icmpv6<E, RouterSolicitation> {
     #[inline]
-    /// Unused field that must be initialized to zero by sender and ignored
-    /// by the receiver.
-    pub fn reserved(&self) -> u32 {
-        u32::from_be(self.payload().reserved)
-    }
-
-    #[inline]
     fn cascade(&mut self) {
         self.compute_checksum();
         self.envelope_mut().cascade();
@@ -86,7 +82,6 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, RouterSolicitation> {
             .field("type", &format!("{}", self.msg_type()))
             .field("code", &self.code())
             .field("checksum", &format!("0x{:04x}", self.checksum()))
-            .field("reserved", &self.reserved())
             .finish()
     }
 }
@@ -113,7 +108,6 @@ mod tests {
 
         if let Ok(Icmpv6Message::RouterSolicitation(solicit)) = ipv6.parse_icmpv6() {
             assert_eq!(Icmpv6Types::RouterSolicitation, solicit.msg_type());
-            assert_eq!(0, solicit.reserved());
         } else {
             panic!("bad packet");
         }

--- a/core/src/packets/icmp/v6/time_exceeded.rs
+++ b/core/src/packets/icmp/v6/time_exceeded.rs
@@ -19,7 +19,7 @@
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
+use crate::{Icmpv6Packet, SizeOf};
 use std::fmt;
 
 /// Time Exceeded Message defined in [`IETF RFC 4443`].
@@ -37,7 +37,10 @@ use std::fmt;
 /// |               exceeding the minimum IPv6 MTU [IPv6]           |
 /// ```
 ///
+/// The fields are accessible through [`Icmpv6<E, TimeExceeded>`].
+///
 /// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-3.3
+/// [`Icmpv6<E, TimeExceeded>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct TimeExceeded {

--- a/core/src/packets/icmp/v6/too_big.rs
+++ b/core/src/packets/icmp/v6/too_big.rs
@@ -19,7 +19,7 @@
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::Packet;
-use crate::{Icmpv6Packet, Result, SizeOf};
+use crate::{Icmpv6Packet, SizeOf};
 use std::fmt;
 
 /// Packet Too Big Message defined in [`IETF RFC 4443`].
@@ -39,7 +39,10 @@ use std::fmt;
 ///
 /// - *MTU*:        The Maximum Transmission Unit of the next-hop link.
 ///
+/// The fields are accessible through [`Icmpv6<E, PacketTooBig>`].
+///
 /// [`IETF RFC 4443`]: https://tools.ietf.org/html/rfc4443#section-3.2
+/// [`Icmpv6<E, PacketTooBig>`]: Icmpv6
 #[derive(Clone, Copy, Debug, Default, Icmpv6Packet, SizeOf)]
 #[repr(C, packed)]
 pub struct PacketTooBig {

--- a/core/src/packets/mbuf.rs
+++ b/core/src/packets/mbuf.rs
@@ -17,7 +17,8 @@
 */
 
 use crate::packets::{Header, Packet};
-use crate::{Mbuf, Result};
+use crate::Mbuf;
+use failure::Fallible;
 
 // Unit header use to implement `Packet` trait for `Mbuf`.
 impl Header for () {}
@@ -73,7 +74,7 @@ impl Packet for Mbuf {
 
     #[doc(hidden)]
     #[inline]
-    fn do_parse(envelope: Self::Envelope) -> Result<Self>
+    fn do_parse(envelope: Self::Envelope) -> Fallible<Self>
     where
         Self: Sized,
     {
@@ -82,7 +83,7 @@ impl Packet for Mbuf {
 
     #[doc(hidden)]
     #[inline]
-    fn do_push(envelope: Self::Envelope) -> Result<Self>
+    fn do_push(envelope: Self::Envelope) -> Fallible<Self>
     where
         Self: Sized,
     {
@@ -90,7 +91,7 @@ impl Packet for Mbuf {
     }
 
     #[inline]
-    fn remove(self) -> Result<Self::Envelope> {
+    fn remove(self) -> Fallible<Self::Envelope> {
         Ok(self)
     }
 

--- a/core/src/packets/mod.rs
+++ b/core/src/packets/mod.rs
@@ -30,8 +30,8 @@ pub use self::ethernet::*;
 pub use self::tcp::*;
 pub use self::udp::*;
 
-use crate::{Mbuf, Result, SizeOf};
-use failure::Fail;
+use crate::{Mbuf, SizeOf};
+use failure::{Fail, Fallible};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -115,7 +115,7 @@ pub trait Packet: Clone {
     /// ownership, use `Packet::peek` instead to gain immutable access
     /// to the packet payload.
     #[inline]
-    fn parse<T: Packet<Envelope = Self>>(self) -> Result<T>
+    fn parse<T: Packet<Envelope = Self>>(self) -> Fallible<T>
     where
         Self: Sized,
     {
@@ -124,7 +124,7 @@ pub trait Packet: Clone {
 
     /// The public `parse::<T>` delegates to this function.
     #[doc(hidden)]
-    fn do_parse(envelope: Self::Envelope) -> Result<Self>
+    fn do_parse(envelope: Self::Envelope) -> Fallible<Self>
     where
         Self: Sized;
 
@@ -133,7 +133,7 @@ pub trait Packet: Clone {
     /// `Packet::peek` returns an immutable reference to the payload. Use
     /// `Packet::parse` instead to gain mutable access to the packet payload.
     #[inline]
-    fn peek<'a, T: Packet<Envelope = Self>>(&'a self) -> Result<Immutable<'a, T>>
+    fn peek<'a, T: Packet<Envelope = Self>>(&'a self) -> Fallible<Immutable<'a, T>>
     where
         Self: Sized,
     {
@@ -142,7 +142,7 @@ pub trait Packet: Clone {
 
     /// Pushes a new packet `T` as the payload.
     #[inline]
-    fn push<T: Packet<Envelope = Self>>(self) -> Result<T>
+    fn push<T: Packet<Envelope = Self>>(self) -> Fallible<T>
     where
         Self: Sized,
     {
@@ -151,7 +151,7 @@ pub trait Packet: Clone {
 
     /// The public `push::<T>` delegates to this function.
     #[doc(hidden)]
-    fn do_push(envelope: Self::Envelope) -> Result<Self>
+    fn do_push(envelope: Self::Envelope) -> Fallible<Self>
     where
         Self: Sized;
 
@@ -159,7 +159,7 @@ pub trait Packet: Clone {
     ///
     /// The packet's payload becomes the payload of its envelope. The
     /// result of the removal is not guaranteed to be a valid packet.
-    fn remove(self) -> Result<Self::Envelope>
+    fn remove(self) -> Fallible<Self::Envelope>
     where
         Self: Sized;
 

--- a/core/src/runtime/core_map.rs
+++ b/core/src/runtime/core_map.rs
@@ -17,8 +17,8 @@
 */
 
 use crate::dpdk::{CoreId, Mempool, MempoolMap, MEMPOOL};
-use crate::{debug, error, ffi, info, Result};
-use failure::Fail;
+use crate::{debug, error, ffi, info};
+use failure::{Fail, Fallible};
 use futures::Future;
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{self, Receiver, SyncSender};
@@ -212,7 +212,7 @@ impl<'a> CoreMapBuilder<'a> {
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub(crate) fn finish(&'a mut self) -> Result<CoreMap> {
+    pub(crate) fn finish(&'a mut self) -> Fallible<CoreMap> {
         let mut map = HashMap::new();
 
         // first initializes the master core, which the current running
@@ -301,7 +301,7 @@ impl<'a> CoreMapBuilder<'a> {
 fn init_master_core(
     id: CoreId,
     mempool: *mut ffi::rte_mempool,
-) -> Result<(MasterExecutor, CoreExecutor)> {
+) -> Fallible<(MasterExecutor, CoreExecutor)> {
     // affinitize the running thread to this core.
     id.set_thread_affinity()?;
 
@@ -341,7 +341,7 @@ fn init_master_core(
 fn init_background_core(
     id: CoreId,
     mempool: *mut ffi::rte_mempool,
-) -> Result<(
+) -> Fallible<(
     CurrentThread<Timer<ParkThread>>,
     Park,
     Shutdown,

--- a/core/src/testils/byte_arrays.rs
+++ b/core/src/testils/byte_arrays.rs
@@ -18,9 +18,9 @@
 
 //! Hand-crafted packet byte-arrays for testing.
 
-/// A VLAN 802.1Q packet.
+/// A VLAN Dot1q (802.1Q) packet.
 #[rustfmt::skip]
-pub const VLAN_802_1Q_PACKET: [u8; 64] = [
+pub const VLAN_DOT1Q_PACKET: [u8; 64] = [
 // Ethernet header
     0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
@@ -38,9 +38,9 @@ pub const VLAN_802_1Q_PACKET: [u8; 64] = [
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 ];
 
-/// A VLAN 802.1AD packet.
+/// A VLAN QinQ (802.1AD) packet.
 #[rustfmt::skip]
-pub const VLAN_802_1AD_PACKET: [u8; 68] = [
+pub const VLAN_QINQ_PACKET: [u8; 68] = [
 // Ethernet header
     0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x02,

--- a/examples/kni/main.rs
+++ b/examples/kni/main.rs
@@ -18,7 +18,8 @@
 
 use capsule::config::load_config;
 use capsule::metrics;
-use capsule::{batch, Result, Runtime};
+use capsule::{batch, Runtime};
+use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
 use metrics_runtime::observers::YamlBuilder;
 use std::time::Duration;
@@ -31,7 +32,7 @@ fn print_stats() {
     println!("{}", observer.drain());
 }
 
-fn main() -> Result<()> {
+fn main() -> Fallible<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .finish();

--- a/examples/ping4d/main.rs
+++ b/examples/ping4d/main.rs
@@ -21,11 +21,12 @@ use capsule::config::load_config;
 use capsule::packets::icmp::v4::{EchoReply, EchoRequest, Icmpv4};
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::{Ethernet, Packet};
-use capsule::{Mbuf, PortQueue, Result, Runtime};
+use capsule::{Mbuf, PortQueue, Runtime};
+use failure::Fallible;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
-fn reply_echo(packet: &Mbuf) -> Result<Icmpv4<EchoReply>> {
+fn reply_echo(packet: &Mbuf) -> Fallible<Icmpv4<EchoReply>> {
     let reply = Mbuf::new()?;
 
     let ethernet = packet.peek::<Ethernet>()?;
@@ -56,7 +57,7 @@ fn install(q: PortQueue) -> impl Pipeline {
     Poll::new(q.clone()).replace(reply_echo).send(q)
 }
 
-fn main() -> Result<()> {
+fn main() -> Fallible<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .finish();

--- a/examples/pktdump/main.rs
+++ b/examples/pktdump/main.rs
@@ -22,13 +22,14 @@ use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::ip::v6::Ipv6;
 use capsule::packets::ip::IpPacket;
 use capsule::packets::{EtherTypes, Ethernet, Packet, Tcp};
-use capsule::{compose, Mbuf, PortQueue, Result, Runtime};
+use capsule::{compose, Mbuf, PortQueue, Runtime};
 use colored::*;
+use failure::Fallible;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
 #[inline]
-fn dump_eth(packet: Mbuf) -> Result<Ethernet> {
+fn dump_eth(packet: Mbuf) -> Fallible<Ethernet> {
     let ethernet = packet.parse::<Ethernet>()?;
 
     let info_fmt = format!("{:?}", ethernet).magenta().bold();
@@ -38,7 +39,7 @@ fn dump_eth(packet: Mbuf) -> Result<Ethernet> {
 }
 
 #[inline]
-fn dump_v4(ethernet: &Ethernet) -> Result<()> {
+fn dump_v4(ethernet: &Ethernet) -> Fallible<()> {
     let v4 = ethernet.peek::<Ipv4>()?;
     let info_fmt = format!("{:?}", v4).yellow();
     println!("{}", info_fmt);
@@ -50,7 +51,7 @@ fn dump_v4(ethernet: &Ethernet) -> Result<()> {
 }
 
 #[inline]
-fn dump_v6(ethernet: &Ethernet) -> Result<()> {
+fn dump_v6(ethernet: &Ethernet) -> Fallible<()> {
     let v6 = ethernet.peek::<Ipv6>()?;
     let info_fmt = format!("{:?}", v6).cyan();
     println!("{}", info_fmt);
@@ -89,7 +90,7 @@ fn install(q: PortQueue) -> impl Pipeline {
         .send(q)
 }
 
-fn main() -> Result<()> {
+fn main() -> Fallible<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .finish();

--- a/examples/signals/main.rs
+++ b/examples/signals/main.rs
@@ -17,8 +17,9 @@
 */
 
 use capsule::config::load_config;
+use capsule::Runtime;
 use capsule::UnixSignal::{self, *};
-use capsule::{Result, Runtime};
+use failure::Fallible;
 use tracing::{info, Level};
 use tracing_subscriber::fmt;
 
@@ -30,7 +31,7 @@ fn on_signal(signal: UnixSignal) -> bool {
     }
 }
 
-fn main() -> Result<()> {
+fn main() -> Fallible<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .finish();

--- a/examples/skeleton/main.rs
+++ b/examples/skeleton/main.rs
@@ -17,11 +17,12 @@
 */
 
 use capsule::config::load_config;
-use capsule::{Result, Runtime};
+use capsule::Runtime;
+use failure::Fallible;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
-fn main() -> Result<()> {
+fn main() -> Fallible<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::TRACE)
         .finish();

--- a/examples/syn-flood/main.rs
+++ b/examples/syn-flood/main.rs
@@ -21,7 +21,8 @@ use capsule::config::load_config;
 use capsule::metrics;
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::{Ethernet, Packet, Tcp};
-use capsule::{batch, Mbuf, PortQueue, Result, Runtime};
+use capsule::{batch, Mbuf, PortQueue, Runtime};
+use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
 use metrics_runtime::observers::YamlBuilder;
 use std::collections::HashMap;
@@ -72,7 +73,7 @@ fn print_stats() {
     println!("{}", observer.drain());
 }
 
-fn main() -> Result<()> {
+fn main() -> Fallible<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .finish();

--- a/macros/src/derive_packet.rs
+++ b/macros/src/derive_packet.rs
@@ -66,13 +66,13 @@ pub fn gen_icmpv6(input: syn::DeriveInput) -> TokenStream {
 
             #[doc(hidden)]
             #[inline]
-            fn do_parse(envelope: Self::Envelope) -> Result<Self> {
+            fn do_parse(envelope: Self::Envelope) -> failure::Fallible<Self> {
                 use crate::ensure;
                 use crate::packets::ip::{IpPacket, ProtocolNumbers};
                 use crate::packets::{CondRc, ParseError};
 
                 ensure!(
-                    envelope.next_proto() == ProtocolNumbers::Icmpv6,
+                    envelope.next_protocol() == ProtocolNumbers::Icmpv6,
                     ParseError::new("not an ICMPv6 packet.")
                 );
 
@@ -91,7 +91,7 @@ pub fn gen_icmpv6(input: syn::DeriveInput) -> TokenStream {
 
             #[doc(hidden)]
             #[inline]
-            fn do_push(mut envelope: Self::Envelope) -> Result<Self> {
+            fn do_push(mut envelope: Self::Envelope) -> failure::Fallible<Self> {
                 use crate::packets::ip::{IpPacket, ProtocolNumbers};
                 use crate::packets::CondRc;
 
@@ -118,7 +118,7 @@ pub fn gen_icmpv6(input: syn::DeriveInput) -> TokenStream {
             }
 
             #[inline]
-            fn remove(mut self) -> Result<Self::Envelope> {
+            fn remove(mut self) -> failure::Fallible<Self::Envelope> {
                 let offset = self.offset();
                 let len = self.header_len();
                 self.mbuf_mut().shrink(offset, len)?;
@@ -187,13 +187,13 @@ pub fn gen_icmpv4(input: syn::DeriveInput) -> TokenStream {
 
             #[doc(hidden)]
             #[inline]
-            fn do_parse(envelope: Self::Envelope) -> Result<Self> {
+            fn do_parse(envelope: Self::Envelope) -> failure::Fallible<Self> {
                 use crate::ensure;
                 use crate::packets::ip::{IpPacket, ProtocolNumbers};
                 use crate::packets::{CondRc, ParseError};
 
                 ensure!(
-                    envelope.next_proto() == ProtocolNumbers::Icmpv4,
+                    envelope.next_protocol() == ProtocolNumbers::Icmpv4,
                     ParseError::new("not an ICMPv4 packet.")
                 );
 
@@ -212,7 +212,7 @@ pub fn gen_icmpv4(input: syn::DeriveInput) -> TokenStream {
 
             #[doc(hidden)]
             #[inline]
-            fn do_push(mut envelope: Self::Envelope) -> Result<Self> {
+            fn do_push(mut envelope: Self::Envelope) -> failure::Fallible<Self> {
                 use crate::packets::ip::{IpPacket, ProtocolNumbers};
                 use crate::packets::CondRc;
 
@@ -233,13 +233,13 @@ pub fn gen_icmpv4(input: syn::DeriveInput) -> TokenStream {
                 packet.header_mut().msg_type = #name::msg_type().0;
                 packet
                     .envelope_mut()
-                    .set_next_proto(ProtocolNumbers::Icmpv4);
+                    .set_next_protocol(ProtocolNumbers::Icmpv4);
 
                 Ok(packet)
             }
 
             #[inline]
-            fn remove(mut self) -> Result<Self::Envelope> {
+            fn remove(mut self) -> failure::Fallible<Self::Envelope> {
                 let offset = self.offset();
                 let len = self.header_len();
                 self.mbuf_mut().shrink(offset, len)?;


### PR DESCRIPTION
## Description

some housekeeping, including:

* dismiss a couple old TODO items
* cleanup VLAN Dot1q and QinQ structs
* link ICMP payloads to packet implementations
* delete some unused functions
* add PacketTooBig and TimeExceeded to Icmpv6Parse
* general doc fix and cleanup
* rename `IpPacket::next_proto` to `next_protocol`
* link headers to packet implementations
* migrate to failure::Fallible

## Type of change

- [x] Breaking change