### PR TITLE
fix prematurely freeing the message buffer

### DIFF
--- a/core/src/batch/group_by.rs
+++ b/core/src/batch/group_by.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 /// through the bridge. Because the pipeline execution is depth first,
 /// this is the most efficient way storage wise.
 #[allow(missing_debug_implementations)]
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct Bridge<T: Packet>(Rc<Cell<Option<T>>>);
 
 impl<T: Packet> Bridge<T> {
@@ -40,6 +40,12 @@ impl<T: Packet> Bridge<T> {
     /// Feeds a packet into the bridge container.
     pub fn set(&self, pkt: T) {
         self.0.set(Some(pkt));
+    }
+}
+
+impl<T: Packet> Clone for Bridge<T> {
+    fn clone(&self) -> Self {
+        Bridge(Rc::clone(&self.0))
     }
 }
 

--- a/core/src/dpdk/mbuf.rs
+++ b/core/src/dpdk/mbuf.rs
@@ -376,10 +376,16 @@ impl Mbuf {
     }
 
     /// Clones the reference to the underlying message buffer.
-    pub(crate) fn shallow_clone(&self) -> Self {
+    ///
+    /// Because the original and the clone share the same message buffer,
+    /// the buffer is mutable through both instances. Changes made through
+    /// one copy could completely invalidate the other and make it unsafe
+    /// to use.
+    pub(crate) unsafe fn shallow_clone(&self) -> Self {
         Mbuf {
             raw: self.raw,
-            // clones shouldn't return the buffer back to the pool.
+            // clones shouldn't return the buffer back to the pool when
+            // they are dropped.
             should_free: false,
         }
     }

--- a/core/src/packets/ethernet.rs
+++ b/core/src/packets/ethernet.rs
@@ -18,7 +18,7 @@
 
 use crate::dpdk::BufferError;
 use crate::net::MacAddr;
-use crate::packets::{CondRc, Header, Packet};
+use crate::packets::{Header, Internal, Packet, PacketBase};
 use crate::{ensure, Mbuf, SizeOf};
 use failure::Fallible;
 use std::fmt;
@@ -115,9 +115,8 @@ const VLAN_802_1AD: u16 = 0x88a8;
 ///
 /// [`IEEE 802.1Q`]: https://en.wikipedia.org/wiki/IEEE_802.1Q
 /// [`IEEE 802.1ad`]: https://en.wikipedia.org/wiki/IEEE_802.1ad
-#[derive(Clone)]
 pub struct Ethernet {
-    envelope: CondRc<Mbuf>,
+    envelope: Mbuf,
     header: NonNull<EthernetHeader>,
     offset: usize,
 }
@@ -215,6 +214,16 @@ impl fmt::Debug for Ethernet {
     }
 }
 
+impl PacketBase for Ethernet {
+    fn clone(&self, internal: Internal) -> Self {
+        Ethernet {
+            envelope: self.envelope.clone(internal),
+            header: self.header,
+            offset: self.offset,
+        }
+    }
+}
+
 impl Packet for Ethernet {
     type Header = EthernetHeader;
     type Envelope = Mbuf;
@@ -265,7 +274,7 @@ impl Packet for Ethernet {
         let header = mbuf.read_data(offset)?;
 
         let packet = Ethernet {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         };
@@ -292,7 +301,7 @@ impl Packet for Ethernet {
         let header = mbuf.write_data(offset, &Self::Header::default())?;
 
         Ok(Ethernet {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         })
@@ -303,12 +312,12 @@ impl Packet for Ethernet {
         let offset = self.offset();
         let len = self.header_len();
         self.mbuf_mut().shrink(offset, len)?;
-        Ok(self.envelope.into_owned())
+        Ok(self.envelope)
     }
 
     #[inline]
     fn deparse(self) -> Self::Envelope {
-        self.envelope.into_owned()
+        self.envelope
     }
 }
 

--- a/core/src/packets/ethernet.rs
+++ b/core/src/packets/ethernet.rs
@@ -215,7 +215,7 @@ impl fmt::Debug for Ethernet {
 }
 
 impl PacketBase for Ethernet {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Ethernet {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -26,7 +26,7 @@ pub use self::echo_request::*;
 
 use crate::packets::ip::v4::Ipv4;
 use crate::packets::ip::{IpPacket, ProtocolNumbers};
-use crate::packets::{checksum, CondRc, Header, Packet, ParseError};
+use crate::packets::{checksum, Header, Internal, Packet, PacketBase, ParseError};
 use crate::{ensure, SizeOf};
 use failure::Fallible;
 use std::fmt;
@@ -68,9 +68,8 @@ use std::ptr::NonNull;
 ///
 /// [`IETF RFC 792`]: https://tools.ietf.org/html/rfc792
 /// [`Icmpv4Payload`]: Icmpv4Payload
-#[derive(Clone)]
 pub struct Icmpv4<P: Icmpv4Payload> {
-    envelope: CondRc<Ipv4>,
+    envelope: Ipv4,
     header: NonNull<Icmpv4Header>,
     payload: NonNull<P>,
     offset: usize,
@@ -96,6 +95,17 @@ impl Icmpv4Packet<()> for Icmpv4<()> {
 
     fn payload_mut(&mut self) -> &mut () {
         unsafe { self.payload.as_mut() }
+    }
+}
+
+impl PacketBase for Icmpv4<()> {
+    fn clone(&self, internal: Internal) -> Self {
+        Icmpv4::<()> {
+            envelope: self.envelope.clone(internal),
+            header: self.header,
+            payload: self.payload,
+            offset: self.offset,
+        }
     }
 }
 
@@ -144,7 +154,7 @@ impl Packet for Icmpv4<()> {
         let payload = mbuf.read_data(offset + Self::Header::size_of())?;
 
         Ok(Icmpv4 {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             payload,
             offset,
@@ -162,7 +172,7 @@ impl Packet for Icmpv4<()> {
         let payload = mbuf.write_data(offset + Self::Header::size_of(), &<()>::default())?;
 
         let mut packet = Icmpv4 {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             payload,
             offset,
@@ -181,7 +191,7 @@ impl Packet for Icmpv4<()> {
         let offset = self.offset();
         let len = self.header_len();
         self.mbuf_mut().shrink(offset, len)?;
-        Ok(self.envelope.into_owned())
+        Ok(self.envelope)
     }
 
     #[inline]
@@ -192,7 +202,7 @@ impl Packet for Icmpv4<()> {
 
     #[inline]
     fn deparse(self) -> Self::Envelope {
-        self.envelope.into_owned()
+        self.envelope
     }
 }
 

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -99,7 +99,7 @@ impl Icmpv4Packet<()> for Icmpv4<()> {
 }
 
 impl PacketBase for Icmpv4<()> {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Icmpv4::<()> {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -107,7 +107,7 @@ impl<E: Ipv6Packet> Icmpv6Packet<E, ()> for Icmpv6<E, ()> {
 }
 
 impl<E: Ipv6Packet> PacketBase for Icmpv6<E, ()> {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Icmpv6::<E, ()> {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -374,7 +374,7 @@ impl fmt::Debug for Ipv4 {
 }
 
 impl PacketBase for Ipv4 {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Ipv4 {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -20,7 +20,7 @@
 
 use crate::packets::checksum::{self, PseudoHeader};
 use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
-use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
+use crate::packets::{EtherTypes, Ethernet, Header, Internal, Packet, PacketBase, ParseError};
 use crate::{ensure, SizeOf};
 use failure::Fallible;
 use std::fmt;
@@ -141,9 +141,8 @@ const FLAGS_MF: u16 = 0b0010_0000_0000_0000;
 /// [`IETF RFC 791`]: https://tools.ietf.org/html/rfc791#section-3.1
 /// [`IETF RFC 2474`]: https://tools.ietf.org/html/rfc2474
 /// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
-#[derive(Clone)]
 pub struct Ipv4 {
-    envelope: CondRc<Ethernet>,
+    envelope: Ethernet,
     header: NonNull<Ipv4Header>,
     offset: usize,
 }
@@ -374,6 +373,16 @@ impl fmt::Debug for Ipv4 {
     }
 }
 
+impl PacketBase for Ipv4 {
+    fn clone(&self, internal: Internal) -> Self {
+        Ipv4 {
+            envelope: self.envelope.clone(internal),
+            header: self.header,
+            offset: self.offset,
+        }
+    }
+}
+
 impl Packet for Ipv4 {
     type Header = Ipv4Header;
     type Envelope = Ethernet;
@@ -418,7 +427,7 @@ impl Packet for Ipv4 {
         let header = mbuf.read_data(offset)?;
 
         Ok(Ipv4 {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         })
@@ -436,7 +445,7 @@ impl Packet for Ipv4 {
         envelope.set_ether_type(EtherTypes::Ipv4);
 
         Ok(Ipv4 {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         })
@@ -447,7 +456,7 @@ impl Packet for Ipv4 {
         let offset = self.offset();
         let len = self.header_len();
         self.mbuf_mut().shrink(offset, len)?;
-        Ok(self.envelope.into_owned())
+        Ok(self.envelope)
     }
 
     #[inline]
@@ -459,7 +468,7 @@ impl Packet for Ipv4 {
 
     #[inline]
     fn deparse(self) -> Self::Envelope {
-        self.envelope.into_owned()
+        self.envelope
     }
 }
 

--- a/core/src/packets/ip/v6/fragment.rs
+++ b/core/src/packets/ip/v6/fragment.rs
@@ -130,7 +130,7 @@ impl<E: Ipv6Packet> fmt::Debug for Fragment<E> {
 }
 
 impl<E: Ipv6Packet> PacketBase for Fragment<E> {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Fragment::<E> {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/ip/v6/fragment.rs
+++ b/core/src/packets/ip/v6/fragment.rs
@@ -19,7 +19,7 @@
 use crate::packets::checksum::PseudoHeader;
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::ip::{IpPacket, ProtocolNumber, ProtocolNumbers};
-use crate::packets::{CondRc, Header, Packet};
+use crate::packets::{Header, Internal, Packet, PacketBase};
 use crate::SizeOf;
 use failure::Fallible;
 use std::fmt;
@@ -69,9 +69,8 @@ const FLAG_MORE: u16 = 0b1;
 /// a valid packet without additional fixes.
 ///
 /// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-4.5
-#[derive(Clone)]
 pub struct Fragment<E: Ipv6Packet> {
-    envelope: CondRc<E>,
+    envelope: E,
     header: NonNull<FragmentHeader>,
     offset: usize,
 }
@@ -130,6 +129,16 @@ impl<E: Ipv6Packet> fmt::Debug for Fragment<E> {
     }
 }
 
+impl<E: Ipv6Packet> PacketBase for Fragment<E> {
+    fn clone(&self, internal: Internal) -> Self {
+        Fragment::<E> {
+            envelope: self.envelope.clone(internal),
+            header: self.header,
+            offset: self.offset,
+        }
+    }
+}
+
 impl<E: Ipv6Packet> Packet for Fragment<E> {
     type Header = FragmentHeader;
     type Envelope = E;
@@ -174,7 +183,7 @@ impl<E: Ipv6Packet> Packet for Fragment<E> {
         let header = mbuf.read_data(offset)?;
 
         Ok(Fragment {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         })
@@ -190,7 +199,7 @@ impl<E: Ipv6Packet> Packet for Fragment<E> {
         let header = mbuf.write_data(offset, &Self::Header::default())?;
 
         let mut packet = Fragment {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         };
@@ -210,12 +219,12 @@ impl<E: Ipv6Packet> Packet for Fragment<E> {
         let next_header = self.next_header();
         self.mbuf_mut().shrink(offset, len)?;
         self.envelope_mut().set_next_header(next_header);
-        Ok(self.envelope.into_owned())
+        Ok(self.envelope)
     }
 
     #[inline]
     fn deparse(self) -> Self::Envelope {
-        self.envelope.into_owned()
+        self.envelope
     }
 }
 

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -26,7 +26,7 @@ pub use self::srh::*;
 
 use crate::packets::checksum::PseudoHeader;
 use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
-use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
+use crate::packets::{EtherTypes, Ethernet, Header, Internal, Packet, PacketBase, ParseError};
 use crate::{ensure, SizeOf};
 use failure::Fallible;
 use std::fmt;
@@ -94,9 +94,8 @@ const FLOW: u32 = 0xfffff;
 /// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-3
 /// [`IETF RFC 2474`]: https://tools.ietf.org/html/rfc2474
 /// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
-#[derive(Clone)]
 pub struct Ipv6 {
-    envelope: CondRc<Ethernet>,
+    envelope: Ethernet,
     header: NonNull<Ipv6Header>,
     offset: usize,
 }
@@ -219,6 +218,16 @@ impl fmt::Debug for Ipv6 {
     }
 }
 
+impl PacketBase for Ipv6 {
+    fn clone(&self, internal: Internal) -> Self {
+        Ipv6 {
+            envelope: self.envelope.clone(internal),
+            header: self.header,
+            offset: self.offset,
+        }
+    }
+}
+
 impl Packet for Ipv6 {
     type Header = Ipv6Header;
     type Envelope = Ethernet;
@@ -263,7 +272,7 @@ impl Packet for Ipv6 {
         let header = mbuf.read_data(offset)?;
 
         Ok(Ipv6 {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         })
@@ -281,7 +290,7 @@ impl Packet for Ipv6 {
         envelope.set_ether_type(EtherTypes::Ipv6);
 
         Ok(Ipv6 {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             offset,
         })
@@ -292,7 +301,7 @@ impl Packet for Ipv6 {
         let offset = self.offset();
         let len = self.header_len();
         self.mbuf_mut().shrink(offset, len)?;
-        Ok(self.envelope.into_owned())
+        Ok(self.envelope)
     }
 
     #[inline]
@@ -304,7 +313,7 @@ impl Packet for Ipv6 {
 
     #[inline]
     fn deparse(self) -> Self::Envelope {
-        self.envelope.into_owned()
+        self.envelope
     }
 }
 

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -219,7 +219,7 @@ impl fmt::Debug for Ipv6 {
 }
 
 impl PacketBase for Ipv6 {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Ipv6 {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -19,7 +19,7 @@
 use crate::packets::checksum::PseudoHeader;
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::ip::{IpPacket, ProtocolNumber, ProtocolNumbers};
-use crate::packets::{CondRc, Header, Packet, ParseError};
+use crate::packets::{Header, Internal, Packet, PacketBase, ParseError};
 use crate::{ensure, SizeOf};
 use failure::{Fail, Fallible};
 use std::fmt;
@@ -103,9 +103,8 @@ use std::ptr::NonNull;
 ///
 /// [`IETF Draft`]: https://tools.ietf.org/html/draft-ietf-6man-segment-routing-header-26#section-2
 /// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-4.4
-#[derive(Clone)]
 pub struct SegmentRouting<E: Ipv6Packet> {
-    envelope: CondRc<E>,
+    envelope: E,
     header: NonNull<SegmentRoutingHeader>,
     segments: NonNull<[Ipv6Addr]>,
     offset: usize,
@@ -239,6 +238,17 @@ impl<E: Ipv6Packet> fmt::Debug for SegmentRouting<E> {
     }
 }
 
+impl<E: Ipv6Packet> PacketBase for SegmentRouting<E> {
+    fn clone(&self, internal: Internal) -> Self {
+        SegmentRouting::<E> {
+            envelope: self.envelope.clone(internal),
+            header: self.header,
+            segments: self.segments,
+            offset: self.offset,
+        }
+    }
+}
+
 impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
     type Header = SegmentRoutingHeader;
     type Envelope = E;
@@ -297,7 +307,7 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
             )?;
 
             Ok(SegmentRouting {
-                envelope: CondRc::new(envelope),
+                envelope,
                 header,
                 segments,
                 offset,
@@ -320,7 +330,7 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
             mbuf.write_data_slice(offset + Self::Header::size_of(), &[Ipv6Addr::UNSPECIFIED])?;
 
         let mut packet = SegmentRouting {
-            envelope: CondRc::new(envelope),
+            envelope,
             header,
             segments,
             offset,
@@ -341,12 +351,12 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
         let next_header = self.next_header();
         self.mbuf_mut().shrink(offset, len)?;
         self.envelope_mut().set_next_header(next_header);
-        Ok(self.envelope.into_owned())
+        Ok(self.envelope)
     }
 
     #[inline]
     fn deparse(self) -> Self::Envelope {
-        self.envelope.into_owned()
+        self.envelope
     }
 }
 

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -239,7 +239,7 @@ impl<E: Ipv6Packet> fmt::Debug for SegmentRouting<E> {
 }
 
 impl<E: Ipv6Packet> PacketBase for SegmentRouting<E> {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         SegmentRouting::<E> {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/mbuf.rs
+++ b/core/src/packets/mbuf.rs
@@ -24,7 +24,7 @@ use failure::Fallible;
 impl Header for () {}
 
 impl PacketBase for Mbuf {
-    fn clone(&self, _internal: Internal) -> Self {
+    unsafe fn clone(&self, _internal: Internal) -> Self {
         self.shallow_clone()
     }
 }

--- a/core/src/packets/mbuf.rs
+++ b/core/src/packets/mbuf.rs
@@ -16,12 +16,18 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-use crate::packets::{Header, Packet};
+use crate::packets::{Header, Internal, Packet, PacketBase};
 use crate::Mbuf;
 use failure::Fallible;
 
 // Unit header use to implement `Packet` trait for `Mbuf`.
 impl Header for () {}
+
+impl PacketBase for Mbuf {
+    fn clone(&self, _internal: Internal) -> Self {
+        self.shallow_clone()
+    }
+}
 
 // make the message buffer behave like a packet.
 impl Packet for Mbuf {

--- a/core/src/packets/mbuf.rs
+++ b/core/src/packets/mbuf.rs
@@ -16,18 +16,12 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-use crate::packets::{Header, Internal, Packet, PacketBase};
+use crate::packets::{Header, Packet};
 use crate::Mbuf;
 use failure::Fallible;
 
 // Unit header use to implement `Packet` trait for `Mbuf`.
 impl Header for () {}
-
-impl PacketBase for Mbuf {
-    unsafe fn clone(&self, _internal: Internal) -> Self {
-        self.shallow_clone()
-    }
-}
 
 // make the message buffer behave like a packet.
 impl Packet for Mbuf {

--- a/core/src/packets/tcp.rs
+++ b/core/src/packets/tcp.rs
@@ -478,7 +478,7 @@ impl<E: IpPacket> fmt::Debug for Tcp<E> {
 }
 
 impl<E: IpPacket> PacketBase for Tcp<E> {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Tcp::<E> {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/packets/udp.rs
+++ b/core/src/packets/udp.rs
@@ -212,7 +212,7 @@ impl<E: IpPacket> fmt::Debug for Udp<E> {
 }
 
 impl<E: IpPacket> PacketBase for Udp<E> {
-    fn clone(&self, internal: Internal) -> Self {
+    unsafe fn clone(&self, internal: Internal) -> Self {
         Udp::<E> {
             envelope: self.envelope.clone(internal),
             header: self.header,

--- a/core/src/pcap.rs
+++ b/core/src/pcap.rs
@@ -18,7 +18,6 @@
 
 use crate::dpdk::{CoreId, PortId};
 use crate::ffi::{self, ToCString, ToResult};
-use crate::packets::Packet;
 use crate::{debug, error};
 use failure::Fallible;
 use std::fmt;
@@ -79,29 +78,28 @@ impl Pcap {
     }
 
     /// Write packets to PCAP file handler.
-    pub(crate) fn write<T: Packet>(&self, packets: &[T]) -> Fallible<()> {
-        packets.iter().try_for_each(|p| self.dump_packet(p))?;
+    pub(crate) fn write(&self, ptrs: &[*mut ffi::rte_mbuf]) -> Fallible<()> {
+        ptrs.iter()
+            .try_for_each(|&p| unsafe { self.dump_packet(p) })?;
         self.flush()
     }
 
-    fn dump_packet<T: Packet>(&self, packet: &T) -> Fallible<()> {
+    unsafe fn dump_packet(&self, ptr: *mut ffi::rte_mbuf) -> Fallible<()> {
         let mut pcap_hdr = ffi::pcap_pkthdr::default();
-        pcap_hdr.len = packet.mbuf().data_len() as u32;
+        pcap_hdr.len = (*ptr).data_len as u32;
         pcap_hdr.caplen = pcap_hdr.len;
 
-        unsafe {
-            libc::gettimeofday(
-                &mut pcap_hdr.ts as *mut ffi::timeval as *mut libc::timeval,
-                std::ptr::null_mut(),
-            )
-            .to_result()?;
+        libc::gettimeofday(
+            &mut pcap_hdr.ts as *mut ffi::timeval as *mut libc::timeval,
+            std::ptr::null_mut(),
+        )
+        .to_result()?;
 
-            ffi::pcap_dump(
-                self.dumper.as_ptr() as *mut raw::c_uchar,
-                &pcap_hdr,
-                packet.mbuf().data_address(0),
-            );
-        }
+        ffi::pcap_dump(
+            self.dumper.as_ptr() as *mut raw::c_uchar,
+            &pcap_hdr,
+            ((*ptr).buf_addr as *mut u8).offset((*ptr).data_off as isize),
+        );
 
         Ok(())
     }
@@ -143,13 +141,13 @@ pub(crate) fn create_for_queues(port: PortId, core: CoreId) -> Fallible<()> {
 /// # Example
 ///
 /// ```
-/// pcap::append_and_write(self.port_id, CoreId::current(), "rx", &mbufs);
+/// pcap::append_and_write(self.port_id, CoreId::current(), "rx", &ptrs);
 /// ```
-pub(crate) fn append_and_write<T: Packet>(
+pub(crate) fn append_and_write(
     port: PortId,
     core: CoreId,
     tx_or_rx: &str,
-    packets: &[T],
+    ptrs: &[*mut ffi::rte_mbuf],
 ) {
     let path = String::from(format!("{:?}-{:?}-{}.pcap", port, core, tx_or_rx).as_str());
     let _ = Pcap::append(path.as_str())
@@ -161,7 +159,7 @@ pub(crate) fn append_and_write<T: Packet>(
             )
         })
         .map(|pcap| {
-            pcap.write(&packets).map_err(|err| {
+            pcap.write(&ptrs).map_err(|err| {
                 error!(
                     message = "can't write packets to pcap file",
                     pcap = path.as_str(),
@@ -174,8 +172,6 @@ pub(crate) fn append_and_write<T: Packet>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packets::ip::v4::Ipv4;
-    use crate::packets::{Ethernet, Udp};
     use crate::testils::byte_arrays::IPV4_UDP_PACKET;
     use crate::Mbuf;
     use std::fs;
@@ -205,13 +201,10 @@ mod tests {
     #[capsule::test]
     fn create_pcap_and_write_packet() {
         let writer = Pcap::create("foo.pcap").unwrap();
-        let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
-        let data_len = packet.data_len();
-        let ethernet = packet.parse::<Ethernet>().unwrap();
-        let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let udp = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
+        let data_len = udp.data_len();
 
-        let res = writer.write(&[udp]);
+        let res = writer.write(&[udp.into_ptr()]);
 
         assert!(res.is_ok());
         let len = read_pcap_plen("foo.pcap");
@@ -227,7 +220,7 @@ mod tests {
         let udp2 = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
         let data_len2 = udp2.data_len();
 
-        let packets = vec![udp, udp2];
+        let packets = vec![udp.into_ptr(), udp2.into_ptr()];
         let res = writer.write(&packets);
         assert!(res.is_ok());
         let len = read_pcap_plen("foo1.pcap");
@@ -240,14 +233,11 @@ mod tests {
         let open = Pcap::create("foo2.pcap");
         assert!(open.is_ok());
 
-        let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
-        let data_len = packet.data_len();
-        let ethernet = packet.parse::<Ethernet>().unwrap();
-        let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let udp = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
+        let data_len = udp.data_len();
 
         let writer = Pcap::append("foo2.pcap").unwrap();
-        let res = writer.write(&[udp]);
+        let res = writer.write(&[udp.into_ptr()]);
 
         assert!(res.is_ok());
         let len = read_pcap_plen("foo2.pcap");

--- a/macros/src/derive_packet.rs
+++ b/macros/src/derive_packet.rs
@@ -34,7 +34,7 @@ pub fn gen_icmpv6(input: syn::DeriveInput) -> TokenStream {
         }
 
         impl<E: Ipv6Packet> crate::packets::PacketBase for crate::packets::icmp::v6::Icmpv6<E, #name> {
-            fn clone(&self, internal: crate::packets::Internal) -> Self {
+            unsafe fn clone(&self, internal: crate::packets::Internal) -> Self {
                 Icmpv6::<E, #name> {
                     envelope: self.envelope.clone(internal),
                     header: self.header,
@@ -165,7 +165,7 @@ pub fn gen_icmpv4(input: syn::DeriveInput) -> TokenStream {
         }
 
         impl crate::packets::PacketBase for Icmpv4<#name> {
-            fn clone(&self, internal: crate::packets::Internal) -> Self {
+            unsafe fn clone(&self, internal: crate::packets::Internal) -> Self {
                 Icmpv4::<#name> {
                     envelope: self.envelope.clone(internal),
                     header: self.header,


### PR DESCRIPTION
## Description

fixes #76. `Mbuf` is freed only once and packets are no longer publicly clonable.

## Type of change

- [x] Bug fix