### PR TITLE
use transportable -m arch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: fetch git branches
         run: |
+          apt-get update && apt-get install -y git
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
       - name: install-critcmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,14 @@ jobs:
       options: --privileged
 
     steps:
+      - name: install git
+        run: |
+          apt-get update && apt-get install -y git
+
       - uses: actions/checkout@v2
 
       - name: fetch git branches
         run: |
-          apt-get update && apt-get install -y git
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
       - name: install-critcmp

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -171,7 +171,7 @@ const RTE_DEPS_LIBS: &[&str] = &["numa", "pcap"];
 fn bind(path: &Path) {
     cc::Build::new()
         .file("src/shim.c")
-        .flag("-march=native")
+        .flag("-march=corei7")
         .compile("rte_shim");
 
     bindgen::Builder::default()
@@ -190,7 +190,7 @@ fn bind(path: &Path) {
         .derive_partialeq(true)
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         .clang_arg("-finline-functions")
-        .clang_arg("-march=native")
+        .clang_arg("-march=corei7")
         .rustfmt_bindings(true)
         .generate()
         .expect("Unable to generate bindings")


### PR DESCRIPTION
## Description

Related to change in https://github.com/capsule-rs/sandbox/pull/14 as we move away from native arch instructions. Will need that new container for CI to pass. 
