### PR TITLE
primitive wrapper types for u16 & u32

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,7 +27,7 @@
 #![doc(html_root_url = "https://docs.rs/capsule/0.1.3")]
 
 //! A framework for network function development. Written in Rust, inspired by
-//! [`NetBricks`] and built on Intel's [`Data Plane Development Kit`].
+//! [NetBricks] and built on Intel's [Data Plane Development Kit].
 //!
 //! The goal of Capsule is to offer an ergonomic framework for network function
 //! development that traditionally has high barriers of entry for developers.
@@ -43,17 +43,17 @@
 //! ## Getting started
 //!
 //! The easiest way to start developing Capsule applications is to use the
-//! `Vagrant` [`virtual machine`] and the `Docker` [`sandbox`] provided by the
+//! `Vagrant` [virtual machine] and the `Docker` [sandbox] provided by the
 //! Capsule team. The sandbox is preconfigured with all the necessary tools and
 //! libraries for Capsule development, including:
 //!
-//! * [`DPDK 19.11`]
-//! * [`Clang`] and [`LLVM`]
-//! * [`Rust 1.43`]
-//! * [`rr`] 5.3
+//! * [DPDK 19.11]
+//! * [Clang] and [LLVM]
+//! * [Rust 1.43]
+//! * [rr] 5.3
 //!
 //! For more information on getting started, please check out Capsule's
-//! [`README`], as well as our [`sandbox repo`] for developer environments.
+//! [README], as well as our [sandbox repo] for developer environments.
 //!
 //! ### Adding Capsule as a Cargo dependency
 //!
@@ -80,33 +80,33 @@
 //!
 //! ### Examples
 //!
-//! - [`kni`]: Kernel NIC interface example.
-//! - [`nat64`]: IPv6 to IPv4 NAT gateway example.
-//! - [`ping4d`]: Ping4 daemon example.
-//! - [`pktdump`]: Packet dump example.
-//! - [`signals`]: Linux signal handling example.
-//! - [`skeleton`]: Base skeleton example.
-//! - [`syn-flood`]: TCP SYN flood example.
+//! - [kni]: Kernel NIC interface example.
+//! - [nat64]: IPv6 to IPv4 NAT gateway example.
+//! - [ping4d]: Ping4 daemon example.
+//! - [pktdump]: Packet dump example.
+//! - [signals]: Linux signal handling example.
+//! - [skeleton]: Base skeleton example.
+//! - [syn-flood]: TCP SYN flood example.
 //!
-//! [`NetBricks`]: https://www.usenix.org/system/files/conference/osdi16/osdi16-panda.pdf
-//! [`Data Plane Development Kit`]: https://www.dpdk.org/
-//! [`virtual machine`]: https://github.com/capsule-rs/sandbox/blob/master/Vagrantfile
-//! [`sandbox`]: https://hub.docker.com/repository/docker/getcapsule/sandbox
-//! [`DPDK 19.11`]: https://doc.dpdk.org/guides-19.11/rel_notes/release_19_11.html
-//! [`Clang`]: https://clang.llvm.org/
-//! [`LLVM`]: https://www.llvm.org/
-//! [`Rust 1.43`]: https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html
-//! [`rr`]: https://rr-project.org/
-//! [`README`]: https://github.com/capsule-rs/capsule/blob/master/README.md
-//! [`sandbox repo`]: https://github.com/capsule-rs/sandbox
+//! [NetBricks]: https://www.usenix.org/system/files/conference/osdi16/osdi16-panda.pdf
+//! [Data Plane Development Kit]: https://www.dpdk.org/
+//! [virtual machine]: https://github.com/capsule-rs/sandbox/blob/master/Vagrantfile
+//! [sandbox]: https://hub.docker.com/repository/docker/getcapsule/sandbox
+//! [DPDK 19.11]: https://doc.dpdk.org/guides-19.11/rel_notes/release_19_11.html
+//! [Clang]: https://clang.llvm.org/
+//! [LLVM]: https://www.llvm.org/
+//! [Rust 1.43]: https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html
+//! [rr]: https://rr-project.org/
+//! [README]: https://github.com/capsule-rs/capsule/blob/master/README.md
+//! [sandbox repo]: https://github.com/capsule-rs/sandbox
 //! [`metrics`]: crate::metrics
-//! [`kni`]: https://github.com/capsule-rs/capsule/tree/master/examples/kni
-//! [`nat64`]: https://github.com/capsule-rs/capsule/tree/master/examples/nat64
-//! [`ping4d`]: https://github.com/capsule-rs/capsule/tree/master/examples/ping4d
-//! [`pktdump`]: https://github.com/capsule-rs/capsule/tree/master/examples/pktdump
-//! [`signals`]: https://github.com/capsule-rs/capsule/tree/master/examples/signals
-//! [`skeleton`]: https://github.com/capsule-rs/capsule/tree/master/examples/skeleton
-//! [`syn-flood`]: https://github.com/capsule-rs/capsule/tree/master/examples/syn-flood
+//! [kni]: https://github.com/capsule-rs/capsule/tree/master/examples/kni
+//! [nat64]: https://github.com/capsule-rs/capsule/tree/master/examples/nat64
+//! [ping4d]: https://github.com/capsule-rs/capsule/tree/master/examples/ping4d
+//! [pktdump]: https://github.com/capsule-rs/capsule/tree/master/examples/pktdump
+//! [signals]: https://github.com/capsule-rs/capsule/tree/master/examples/signals
+//! [skeleton]: https://github.com/capsule-rs/capsule/tree/master/examples/skeleton
+//! [syn-flood]: https://github.com/capsule-rs/capsule/tree/master/examples/syn-flood
 
 // alias for the macros
 extern crate self as capsule;

--- a/core/src/net/cidr/v4.rs
+++ b/core/src/net/cidr/v4.rs
@@ -23,9 +23,9 @@ use std::str::FromStr;
 
 const IPV4ADDR_BITS: usize = 32;
 
-/// [`CIDR`] range for IPv4 addresses.
+/// [CIDR] range for IPv4 addresses.
 ///
-/// [`CIDR`]: https://tools.ietf.org/html/rfc4632#section-3.1
+/// [CIDR]: https://tools.ietf.org/html/rfc4632#section-3.1
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ipv4Cidr {
     address: Ipv4Addr,

--- a/core/src/net/cidr/v6.rs
+++ b/core/src/net/cidr/v6.rs
@@ -23,9 +23,9 @@ use std::str::FromStr;
 
 const IPV6ADDR_BITS: usize = 128;
 
-/// [`CIDR`] range for IPv6 addresses.
+/// [CIDR] range for IPv6 addresses.
 ///
-/// [`CIDR`]: https://tools.ietf.org/html/rfc4291#section-2.3
+/// [CIDR]: https://tools.ietf.org/html/rfc4291#section-2.3
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ipv6Cidr {
     address: Ipv6Addr,

--- a/core/src/packets/checksum.rs
+++ b/core/src/packets/checksum.rs
@@ -103,7 +103,7 @@ fn v4_csum(src: Ipv4Addr, dst: Ipv4Addr, packet_len: u16, protocol: ProtocolNumb
 }
 
 /// Calculates the upper-layer checksum using the IPv6 psuedo-header as
-/// defined in [`IETF RFC 2460`].
+/// defined in [IETF RFC 2460].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -119,7 +119,7 @@ fn v4_csum(src: Ipv4Addr, dst: Ipv4Addr, packet_len: u16, protocol: ProtocolNumb
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 ///
-/// [`IETF RFC 2460`]: https://tools.ietf.org/html/rfc2460#section-8.1
+/// [IETF RFC 2460]: https://tools.ietf.org/html/rfc2460#section-8.1
 fn v6_csum(src: Ipv6Addr, dst: Ipv6Addr, packet_len: u16, protocol: ProtocolNumber) -> u32 {
     src.segments().iter().fold(0, |acc, &x| acc + u32::from(x))
         + dst.segments().iter().fold(0, |acc, &x| acc + u32::from(x))
@@ -127,7 +127,7 @@ fn v6_csum(src: Ipv6Addr, dst: Ipv6Addr, packet_len: u16, protocol: ProtocolNumb
         + u32::from(protocol.0)
 }
 
-/// Computes the Internet checksum as defined in [`IETF RFC 1071`].
+/// Computes the Internet checksum as defined in [IETF RFC 1071].
 ///
 /// 1. Adjacent octets to be checksummed are paired to form 16-bit integers,
 /// and the 1's complement sum of these 16-bit integers is formed.
@@ -140,7 +140,7 @@ fn v6_csum(src: Ipv6Addr, dst: Ipv6Addr, packet_len: u16, protocol: ProtocolNumb
 /// set of octets, including the checksum field.  If the result is all 1 bits
 /// (-0 in 1's complement arithmetic), the check succeeds.
 ///
-/// [`IETF RFC 1071`]: https://tools.ietf.org/html/rfc1071
+/// [IETF RFC 1071]: https://tools.ietf.org/html/rfc1071
 #[allow(clippy::cast_ptr_alignment)]
 pub fn compute(pseudo_header_sum: u16, payload: &[u8]) -> u16 {
     let len = payload.len();
@@ -168,7 +168,7 @@ pub fn compute(pseudo_header_sum: u16, payload: &[u8]) -> u16 {
 }
 
 /// Computes the Internet checksum via incremental update as defined in
-/// [`IETF RFC 1624`].
+/// [IETF RFC 1624].
 ///
 /// Given the following notation:
 /// * `HC`  - old checksum in header
@@ -178,7 +178,7 @@ pub fn compute(pseudo_header_sum: u16, payload: &[u8]) -> u16 {
 ///
 /// `HC' = ~(~HC + ~m + m')`
 ///
-/// [`IETF RFC 1624`]: https://tools.ietf.org/html/rfc1624
+/// [IETF RFC 1624]: https://tools.ietf.org/html/rfc1624
 pub fn compute_inc(old_checksum: u16, old_value: &[u16], new_value: &[u16]) -> u16 {
     let mut checksum = old_value
         .iter()

--- a/core/src/packets/ethernet.rs
+++ b/core/src/packets/ethernet.rs
@@ -60,7 +60,7 @@ const VLAN_802_1AD: u16 = 0x88a8;
 /// # 802.1Q aka Dot1q
 ///
 /// For networks support virtual LANs, the frame may include an extra VLAN
-/// tag after the source MAC as specified in [`IEEE 802.1Q`].
+/// tag after the source MAC as specified in [IEEE 802.1Q].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -101,7 +101,7 @@ const VLAN_802_1AD: u16 = 0x88a8;
 ///
 /// # 802.1ad aka QinQ
 ///
-/// The frame may be double tagged as per [`IEEE 802.1ad`].
+/// The frame may be double tagged as per [IEEE 802.1ad].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -116,8 +116,8 @@ const VLAN_802_1AD: u16 = 0x88a8;
 /// S-TAG, or service tag, comes first, followed by the inner C-TAG, or customer
 /// tag. In such cases, 802.1ad specifies a TPID of `0x88a8` for S-TAG.
 ///
-/// [`IEEE 802.1Q`]: https://en.wikipedia.org/wiki/IEEE_802.1Q
-/// [`IEEE 802.1ad`]: https://en.wikipedia.org/wiki/IEEE_802.1ad
+/// [IEEE 802.1Q]: https://en.wikipedia.org/wiki/IEEE_802.1Q
+/// [IEEE 802.1ad]: https://en.wikipedia.org/wiki/IEEE_802.1ad
 pub struct Ethernet {
     envelope: Mbuf,
     header: NonNull<EthernetHeader>,

--- a/core/src/packets/ethernet.rs
+++ b/core/src/packets/ethernet.rs
@@ -18,6 +18,7 @@
 
 use crate::dpdk::BufferError;
 use crate::net::MacAddr;
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::{ensure, Mbuf, SizeOf};
 use failure::Fallible;
@@ -161,7 +162,7 @@ impl Ethernet {
     /// Returns the marker that indicates whether the frame is VLAN.
     #[inline]
     fn vlan_marker(&self) -> u16 {
-        unsafe { u16::from_be(self.header().chunk.ether_type) }
+        unsafe { self.header().chunk.ether_type.into() }
     }
 
     /// Returns the protocol identifier of the payload.
@@ -176,13 +177,13 @@ impl Ethernet {
             }
         };
 
-        EtherType::new(u16::from_be(ether_type))
+        EtherType::new(ether_type.into())
     }
 
     /// Sets the protocol identifier of the payload.
     #[inline]
     pub fn set_ether_type(&mut self, ether_type: EtherType) {
-        let ether_type = u16::to_be(ether_type.0);
+        let ether_type = ether_type.0.into();
         match self.vlan_marker() {
             VLAN_802_1Q => self.header_mut().chunk.dot1q.ether_type = ether_type,
             VLAN_802_1AD => self.header_mut().chunk.qinq.ether_type = ether_type,
@@ -366,8 +367,8 @@ impl fmt::Display for EtherType {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct VlanTag {
-    tpid: u16,
-    tci: u16,
+    tpid: u16be,
+    tci: u16be,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -376,14 +377,15 @@ impl VlanTag {
     #[allow(dead_code)]
     #[inline]
     fn tag_id(&self) -> u16 {
-        self.tpid
+        self.tpid.into()
     }
 
     /// Returns the priority code point.
     #[allow(dead_code)]
     #[inline]
     fn priority(&self) -> u8 {
-        (self.tci >> 13) as u8
+        let tci: u16 = self.tci.into();
+        (tci >> 13) as u8
     }
 
     /// Returns whether the frame is eligible to be dropped in the presence
@@ -391,14 +393,14 @@ impl VlanTag {
     #[allow(dead_code)]
     #[inline]
     fn drop_eligible(&self) -> bool {
-        self.tci & 0x1000 > 0
+        self.tci & u16be::from(0x1000) > u16be::MIN
     }
 
     /// Returns the VLAN identifier.
     #[allow(dead_code)]
     #[inline]
     fn identifier(&self) -> u16 {
-        self.tci & 0x0fff
+        (self.tci & u16be::from(0x0fff)).into()
     }
 }
 
@@ -407,7 +409,7 @@ impl VlanTag {
 #[repr(C, packed)]
 struct Dot1q {
     tag: VlanTag,
-    ether_type: u16,
+    ether_type: u16be,
 }
 
 /// QinQ chunk for a VLAN header.
@@ -416,7 +418,7 @@ struct Dot1q {
 struct Qinq {
     stag: VlanTag,
     ctag: VlanTag,
-    ether_type: u16,
+    ether_type: u16be,
 }
 
 /// The Ethernet header chunk follows the source MAC.
@@ -424,14 +426,16 @@ struct Qinq {
 #[derive(Clone, Copy)]
 #[repr(C, packed)]
 union Chunk {
-    ether_type: u16,
+    ether_type: u16be,
     dot1q: Dot1q,
     qinq: Qinq,
 }
 
 impl Default for Chunk {
     fn default() -> Chunk {
-        Chunk { ether_type: 0 }
+        Chunk {
+            ether_type: u16be::default(),
+        }
     }
 }
 

--- a/core/src/packets/icmp/v4/echo_reply.rs
+++ b/core/src/packets/icmp/v4/echo_reply.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::icmp::v4::{Icmpv4, Icmpv4Message, Icmpv4Packet, Icmpv4Type, Icmpv4Types};
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -65,25 +66,25 @@ impl EchoReply {
     /// Returns the identifier.
     #[inline]
     pub fn identifier(&self) -> u16 {
-        u16::from_be(self.body().identifier)
+        self.body().identifier.into()
     }
 
     /// Sets the identifier.
     #[inline]
     pub fn set_identifier(&mut self, identifier: u16) {
-        self.body_mut().identifier = u16::to_be(identifier);
+        self.body_mut().identifier = identifier.into();
     }
 
     /// Returns the sequence number.
     #[inline]
     pub fn seq_no(&self) -> u16 {
-        u16::from_be(self.body().seq_no)
+        self.body().seq_no.into()
     }
 
     /// Sets the sequence number.
     #[inline]
     pub fn set_seq_no(&mut self, seq_no: u16) {
-        self.body_mut().seq_no = u16::to_be(seq_no);
+        self.body_mut().seq_no = seq_no.into();
     }
 
     /// Returns the offset where the data field in the message body starts.
@@ -195,8 +196,8 @@ impl Icmpv4Message for EchoReply {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct EchoReplyBody {
-    identifier: u16,
-    seq_no: u16,
+    identifier: u16be,
+    seq_no: u16be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v4/echo_request.rs
+++ b/core/src/packets/icmp/v4/echo_request.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::icmp::v4::{Icmpv4, Icmpv4Message, Icmpv4Packet, Icmpv4Type, Icmpv4Types};
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -66,25 +67,25 @@ impl EchoRequest {
     /// Returns the identifier.
     #[inline]
     pub fn identifier(&self) -> u16 {
-        u16::from_be(self.body().identifier)
+        self.body().identifier.into()
     }
 
     /// Sets the identifier.
     #[inline]
     pub fn set_identifier(&mut self, identifier: u16) {
-        self.body_mut().identifier = u16::to_be(identifier);
+        self.body_mut().identifier = identifier.into();
     }
 
     /// Returns the sequence number.
     #[inline]
     pub fn seq_no(&self) -> u16 {
-        u16::from_be(self.body().seq_no)
+        self.body().seq_no.into()
     }
 
     /// Sets the sequence number.
     #[inline]
     pub fn set_seq_no(&mut self, seq_no: u16) {
-        self.body_mut().seq_no = u16::to_be(seq_no);
+        self.body_mut().seq_no = seq_no.into();
     }
 
     /// Returns the offset where the data field in the message body starts.
@@ -196,8 +197,8 @@ impl Icmpv4Message for EchoRequest {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct EchoRequestBody {
-    identifier: u16,
-    seq_no: u16,
+    identifier: u16be,
+    seq_no: u16be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -27,6 +27,7 @@ pub use capsule_macros::Icmpv4Packet;
 
 use crate::packets::ip::v4::Ipv4;
 use crate::packets::ip::ProtocolNumbers;
+use crate::packets::types::u16be;
 use crate::packets::{checksum, Internal, Packet, ParseError};
 use crate::{ensure, SizeOf};
 use failure::{Fail, Fallible};
@@ -105,18 +106,18 @@ impl Icmpv4 {
     /// Returns the checksum.
     #[inline]
     pub fn checksum(&self) -> u16 {
-        u16::from_be(self.header().checksum)
+        self.header().checksum.into()
     }
 
     /// Computes the checksum.
     #[inline]
     pub fn compute_checksum(&mut self) {
-        self.header_mut().checksum = 0;
+        self.header_mut().checksum = u16be::default();
 
         if let Ok(data) = self.mbuf().read_data_slice(self.offset(), self.len()) {
             let data = unsafe { data.as_ref() };
             let checksum = checksum::compute(0, data);
-            self.header_mut().checksum = u16::to_be(checksum);
+            self.header_mut().checksum = checksum.into();
         } else {
             // we are reading till the end of buffer, should never run out
             unreachable!()
@@ -298,7 +299,7 @@ impl fmt::Display for Icmpv4Type {
 pub struct Icmpv4Header {
     msg_type: u8,
     code: u8,
-    checksum: u16,
+    checksum: u16be,
 }
 
 /// A trait all ICMPv4 messages must implement.

--- a/core/src/packets/icmp/v6/echo_reply.rs
+++ b/core/src/packets/icmp/v6/echo_reply.rs
@@ -18,6 +18,7 @@
 
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -66,25 +67,25 @@ impl<E: Ipv6Packet> EchoReply<E> {
     /// Returns the identifier.
     #[inline]
     pub fn identifier(&self) -> u16 {
-        u16::from_be(self.body().identifier)
+        self.body().identifier.into()
     }
 
     /// Sets the identifier.
     #[inline]
     pub fn set_identifier(&mut self, identifier: u16) {
-        self.body_mut().identifier = u16::to_be(identifier);
+        self.body_mut().identifier = identifier.into();
     }
 
     /// Returns the sequence number.
     #[inline]
     pub fn seq_no(&self) -> u16 {
-        u16::from_be(self.body().seq_no)
+        self.body().seq_no.into()
     }
 
     /// Sets the sequence number.
     #[inline]
     pub fn set_seq_no(&mut self, seq_no: u16) {
-        self.body_mut().seq_no = u16::to_be(seq_no);
+        self.body_mut().seq_no = seq_no.into();
     }
 
     /// Returns the offset where the data field in the message body starts.
@@ -194,8 +195,8 @@ impl<E: Ipv6Packet> Icmpv6Message for EchoReply<E> {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct EchoReplyBody {
-    identifier: u16,
-    seq_no: u16,
+    identifier: u16be,
+    seq_no: u16be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v6/echo_request.rs
+++ b/core/src/packets/icmp/v6/echo_request.rs
@@ -18,6 +18,7 @@
 
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -67,25 +68,25 @@ impl<E: Ipv6Packet> EchoRequest<E> {
     /// Returns the identifier.
     #[inline]
     pub fn identifier(&self) -> u16 {
-        u16::from_be(self.body().identifier)
+        self.body().identifier.into()
     }
 
     /// Sets the identifier.
     #[inline]
     pub fn set_identifier(&mut self, identifier: u16) {
-        self.body_mut().identifier = u16::to_be(identifier);
+        self.body_mut().identifier = identifier.into();
     }
 
     /// Returns the sequence number.
     #[inline]
     pub fn seq_no(&self) -> u16 {
-        u16::from_be(self.body().seq_no)
+        self.body().seq_no.into()
     }
 
     /// Sets the sequence number.
     #[inline]
     pub fn set_seq_no(&mut self, seq_no: u16) {
-        self.body_mut().seq_no = u16::to_be(seq_no);
+        self.body_mut().seq_no = seq_no.into();
     }
 
     /// Returns the offset where the data field in the message body starts.
@@ -195,8 +196,8 @@ impl<E: Ipv6Packet> Icmpv6Message for EchoRequest<E> {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct EchoRequestBody {
-    identifier: u16,
-    seq_no: u16,
+    identifier: u16be,
+    seq_no: u16be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -32,6 +32,7 @@ pub use capsule_macros::Icmpv6Packet;
 
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::ip::ProtocolNumbers;
+use crate::packets::types::u16be;
 use crate::packets::{checksum, Internal, Packet, ParseError};
 use crate::{ensure, SizeOf};
 use failure::{Fail, Fallible};
@@ -112,13 +113,13 @@ impl<E: Ipv6Packet> Icmpv6<E> {
     /// Returns the checksum.
     #[inline]
     fn checksum(&self) -> u16 {
-        u16::from_be(self.header().checksum)
+        self.header().checksum.into()
     }
 
     /// Computes the checksum.
     #[inline]
     fn compute_checksum(&mut self) {
-        self.header_mut().checksum = 0;
+        self.header_mut().checksum = u16be::default();
 
         if let Ok(data) = self.mbuf().read_data_slice(self.offset(), self.len()) {
             let data = unsafe { data.as_ref() };
@@ -127,7 +128,7 @@ impl<E: Ipv6Packet> Icmpv6<E> {
                 .pseudo_header(data.len() as u16, ProtocolNumbers::Icmpv6)
                 .sum();
             let checksum = checksum::compute(pseudo_header_sum, data);
-            self.header_mut().checksum = u16::to_be(checksum);
+            self.header_mut().checksum = checksum.into();
         } else {
             // we are reading till the end of buffer, should never run out
             unreachable!()
@@ -356,7 +357,7 @@ impl fmt::Display for Icmpv6Type {
 pub struct Icmpv6Header {
     msg_type: u8,
     code: u8,
-    checksum: u16,
+    checksum: u16be,
 }
 
 /// A trait all ICMPv6 messages must implement.

--- a/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
@@ -19,6 +19,7 @@
 use super::NdpPacket;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -240,7 +241,7 @@ impl<E: Ipv6Packet> NdpPacket for NeighborAdvertisement<E> {
 struct NeighborAdvertisementBody {
     flags: u8,
     reserved1: u8,
-    reserved2: u16,
+    reserved2: u16be,
     target: Ipv6Addr,
 }
 
@@ -249,7 +250,7 @@ impl Default for NeighborAdvertisementBody {
         NeighborAdvertisementBody {
             flags: 0,
             reserved1: 0,
-            reserved2: 0,
+            reserved2: u16be::default(),
             target: Ipv6Addr::UNSPECIFIED,
         }
     }

--- a/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
@@ -19,6 +19,7 @@
 use super::NdpPacket;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
+use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -157,14 +158,14 @@ impl<E: Ipv6Packet> NdpPacket for NeighborSolicitation<E> {
 #[derive(Clone, Copy, Debug, SizeOf)]
 #[repr(C)]
 struct NeighborSolicitationBody {
-    reserved: u32,
+    reserved: u32be,
     target: Ipv6Addr,
 }
 
 impl Default for NeighborSolicitationBody {
     fn default() -> Self {
         NeighborSolicitationBody {
-            reserved: 0,
+            reserved: u32be::default(),
             target: Ipv6Addr::UNSPECIFIED,
         }
     }

--- a/core/src/packets/icmp/v6/ndp/options/mtu.rs
+++ b/core/src/packets/icmp/v6/ndp/options/mtu.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::icmp::v6::ndp::{NdpOption, NdpOptionType, NdpOptionTypes};
+use crate::packets::types::{u16be, u32be};
 use crate::packets::{Internal, ParseError};
 use crate::{ensure, Mbuf, SizeOf};
 use failure::Fallible;
@@ -66,12 +67,12 @@ impl Mtu<'_> {
 
     /// Returns the recommended MTU for the link.
     pub fn mtu(&self) -> u32 {
-        u32::from_be(self.fields().mtu)
+        self.fields().mtu.into()
     }
 
     /// Sets the recommended MTU for the link.
     pub fn set_mtu(&mut self, mtu: u32) {
-        self.fields_mut().mtu = u32::to_be(mtu);
+        self.fields_mut().mtu = mtu.into();
     }
 }
 
@@ -140,8 +141,8 @@ impl<'a> NdpOption<'a> for Mtu<'a> {
 struct MtuFields {
     option_type: u8,
     length: u8,
-    reserved: u16,
-    mtu: u32,
+    reserved: u16be,
+    mtu: u32be,
 }
 
 impl Default for MtuFields {
@@ -149,8 +150,8 @@ impl Default for MtuFields {
         MtuFields {
             option_type: NdpOptionTypes::Mtu.0,
             length: 1,
-            reserved: 0,
-            mtu: 0,
+            reserved: u16be::default(),
+            mtu: u32be::default(),
         }
     }
 }

--- a/core/src/packets/icmp/v6/ndp/options/prefix_info.rs
+++ b/core/src/packets/icmp/v6/ndp/options/prefix_info.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::icmp::v6::ndp::{NdpOption, NdpOptionType, NdpOptionTypes};
+use crate::packets::types::u32be;
 use crate::packets::{Internal, ParseError};
 use crate::{ensure, Mbuf, SizeOf};
 use failure::Fallible;
@@ -157,26 +158,26 @@ impl PrefixInformation<'_> {
     /// the purpose of on-link determination.
     #[inline]
     pub fn valid_lifetime(&self) -> u32 {
-        u32::from_be(self.fields().valid_lifetime)
+        self.fields().valid_lifetime.into()
     }
 
     /// Sets the prefix valid lifetime.
     #[inline]
     pub fn set_valid_lifetime(&mut self, valid_lifetime: u32) {
-        self.fields_mut().valid_lifetime = u32::to_be(valid_lifetime);
+        self.fields_mut().valid_lifetime = valid_lifetime.into();
     }
 
     /// Returns the length of time in seconds that addresses generated from
     /// the prefix via stateless address autoconfiguration remain preferred.
     #[inline]
     pub fn preferred_lifetime(&self) -> u32 {
-        u32::from_be(self.fields().preferred_lifetime)
+        self.fields().preferred_lifetime.into()
     }
 
     /// Sets the preferred lifetime.
     #[inline]
     pub fn set_preferred_lifetime(&mut self, preferred_lifetime: u32) {
-        self.fields_mut().preferred_lifetime = u32::to_be(preferred_lifetime);
+        self.fields_mut().preferred_lifetime = preferred_lifetime.into();
     }
 
     /// Returns the IPv6 prefix.
@@ -272,9 +273,9 @@ struct PrefixInformationFields {
     length: u8,
     prefix_length: u8,
     flags: u8,
-    valid_lifetime: u32,
-    preferred_lifetime: u32,
-    reserved: u32,
+    valid_lifetime: u32be,
+    preferred_lifetime: u32be,
+    reserved: u32be,
     prefix: Ipv6Addr,
 }
 
@@ -285,9 +286,9 @@ impl Default for PrefixInformationFields {
             length: 4,
             prefix_length: 0,
             flags: 0,
-            valid_lifetime: 0,
-            preferred_lifetime: 0,
-            reserved: 0,
+            valid_lifetime: u32be::default(),
+            preferred_lifetime: u32be::default(),
+            reserved: u32be::default(),
             prefix: Ipv6Addr::UNSPECIFIED,
         }
     }

--- a/core/src/packets/icmp/v6/ndp/options/redirected.rs
+++ b/core/src/packets/icmp/v6/ndp/options/redirected.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::icmp::v6::ndp::{NdpOption, NdpOptionType, NdpOptionTypes};
+use crate::packets::types::{u16be, u32be};
 use crate::packets::{Internal, ParseError};
 use crate::{ensure, Mbuf, SizeOf};
 use failure::Fallible;
@@ -203,8 +204,8 @@ impl<'a> NdpOption<'a> for RedirectedHeader<'a> {
 struct RedirectedHeaderFields {
     option_type: u8,
     length: u8,
-    reserved1: u16,
-    reserved2: u32,
+    reserved1: u16be,
+    reserved2: u32be,
 }
 
 impl Default for RedirectedHeaderFields {
@@ -212,8 +213,8 @@ impl Default for RedirectedHeaderFields {
         RedirectedHeaderFields {
             option_type: NdpOptionTypes::RedirectedHeader.0,
             length: 1,
-            reserved1: 0,
-            reserved2: 0,
+            reserved1: u16be::default(),
+            reserved2: u32be::default(),
         }
     }
 }

--- a/core/src/packets/icmp/v6/ndp/redirect.rs
+++ b/core/src/packets/icmp/v6/ndp/redirect.rs
@@ -45,7 +45,7 @@ use std::ptr::NonNull;
 /// +-+-+-+-+-+-+-+-+-+-+-+-
 /// ```
 ///
-/// - *Reserved*:       This field is unused.  It MUST be initialized to
+/// - *Reserved*:       This field is unused. It MUST be initialized to
 ///                     zero by the sender and MUST be ignored by the
 ///                     receiver.
 ///
@@ -59,7 +59,7 @@ use std::ptr::NonNull;
 /// Possible options:
 ///
 /// - *Target link-layer address*:
-///                     The link-layer address for the target.  It SHOULD
+///                     The link-layer address for the target. It SHOULD
 ///                     be included (if known).
 ///
 /// - *Redirected Header*:

--- a/core/src/packets/icmp/v6/ndp/redirect.rs
+++ b/core/src/packets/icmp/v6/ndp/redirect.rs
@@ -19,6 +19,7 @@
 use super::{NdpPacket, RedirectedHeader};
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
+use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -211,7 +212,7 @@ impl<E: Ipv6Packet> NdpPacket for Redirect<E> {
 #[derive(Clone, Copy, Debug, SizeOf)]
 #[repr(C)]
 struct RedirectBody {
-    reserved: u32,
+    reserved: u32be,
     target: Ipv6Addr,
     destination: Ipv6Addr,
 }
@@ -219,7 +220,7 @@ struct RedirectBody {
 impl Default for RedirectBody {
     fn default() -> Self {
         RedirectBody {
-            reserved: 0,
+            reserved: u32be::default(),
             target: Ipv6Addr::UNSPECIFIED,
             destination: Ipv6Addr::UNSPECIFIED,
         }

--- a/core/src/packets/icmp/v6/ndp/router_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/router_advert.rs
@@ -19,6 +19,7 @@
 use super::NdpPacket;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
+use crate::packets::types::{u16be, u32be};
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -166,39 +167,39 @@ impl<E: Ipv6Packet> RouterAdvertisement<E> {
     /// of seconds.
     #[inline]
     pub fn router_lifetime(&self) -> u16 {
-        u16::from_be(self.body().router_lifetime)
+        self.body().router_lifetime.into()
     }
 
     /// Sets the router's default lifetime.
     #[inline]
     pub fn set_router_lifetime(&mut self, router_lifetime: u16) {
-        self.body_mut().router_lifetime = u16::to_be(router_lifetime);
+        self.body_mut().router_lifetime = router_lifetime.into();
     }
 
     /// Returns the time, in milliseconds, that a node assumes a neighbor
     /// is reachable.
     #[inline]
     pub fn reachable_time(&self) -> u32 {
-        u32::from_be(self.body().reachable_time)
+        self.body().reachable_time.into()
     }
 
     /// Sets the neighbor reachable time.
     #[inline]
     pub fn set_reachable_time(&mut self, reachable_time: u32) {
-        self.body_mut().reachable_time = u32::to_be(reachable_time);
+        self.body_mut().reachable_time = reachable_time.into();
     }
 
     /// Returns the time, in milliseconds, between retransmitted Neighbor
     /// Solicitation messages.
     #[inline]
     pub fn retrans_timer(&self) -> u32 {
-        u32::from_be(self.body().retrans_timer)
+        self.body().retrans_timer.into()
     }
 
     /// Sets the retransmission timer.
     #[inline]
     pub fn set_retrans_timer(&mut self, retrans_timer: u32) {
-        self.body_mut().retrans_timer = u32::to_be(retrans_timer);
+        self.body_mut().retrans_timer = retrans_timer.into();
     }
 }
 
@@ -281,9 +282,9 @@ impl<E: Ipv6Packet> NdpPacket for RouterAdvertisement<E> {
 struct RouterAdvertisementBody {
     current_hop_limit: u8,
     flags: u8,
-    router_lifetime: u16,
-    reachable_time: u32,
-    retrans_timer: u32,
+    router_lifetime: u16be,
+    reachable_time: u32be,
+    retrans_timer: u32be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v6/ndp/router_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/router_solicit.rs
@@ -19,6 +19,7 @@
 use super::NdpPacket;
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
+use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -125,7 +126,7 @@ impl<E: Ipv6Packet> NdpPacket for RouterSolicitation<E> {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct RouterSolicitationBody {
-    _reserved: u32,
+    _reserved: u32be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v6/time_exceeded.rs
+++ b/core/src/packets/icmp/v6/time_exceeded.rs
@@ -18,6 +18,7 @@
 
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
+use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -145,7 +146,7 @@ impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct TimeExceededBody {
-    _unused: u32,
+    _unused: u32be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/icmp/v6/too_big.rs
+++ b/core/src/packets/icmp/v6/too_big.rs
@@ -18,6 +18,7 @@
 
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
+use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
 use failure::Fallible;
@@ -62,13 +63,13 @@ impl<E: Ipv6Packet> PacketTooBig<E> {
     /// Returns the MTU of the next-hop link.
     #[inline]
     pub fn mtu(&self) -> u32 {
-        u32::from_be(self.body().mtu)
+        self.body().mtu.into()
     }
 
     /// Sets the MTU of the next-hop link.
     #[inline]
     pub fn set_mtu(&mut self, mtu: u32) {
-        self.body_mut().mtu = u32::to_be(mtu);
+        self.body_mut().mtu = mtu.into();
     }
 
     /// Returns the invoking packet as a `u8` slice.
@@ -170,7 +171,7 @@ impl<E: Ipv6Packet> Icmpv6Message for PacketTooBig<E> {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C, packed)]
 struct PacketTooBigBody {
-    mtu: u32,
+    mtu: u32be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -27,16 +27,16 @@ use failure::{Fail, Fallible};
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 
-/// [`IANA`] recommended default TTL for IP.
+/// [IANA] recommended default TTL for IP.
 ///
-/// [`IANA`]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xml#ip-parameters-2
+/// [IANA]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xml#ip-parameters-2
 pub const DEFAULT_IP_TTL: u8 = 64;
 
-/// [`IANA`] assigned Internet protocol number.
+/// [IANA] assigned Internet protocol number.
 ///
 /// See [`ProtocolNumbers`] for which are current supported.
 ///
-/// [`IANA`]: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+/// [IANA]: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 /// [`ProtocolNumbers`]: crate::packets::ip::ProtocolNumbers
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[repr(C, packed)]

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -28,13 +28,13 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ptr::NonNull;
 
-/// The minimum IPv4 MTU defined in [`IETF RFC 791`].
+/// The minimum IPv4 MTU defined in [IETF RFC 791].
 ///
 /// Every internet module must be able to forward a datagram of 68 octets
 /// without further fragmentation.  This is because an internet header may
 /// be up to 60 octets, and the minimum fragment is 8 octets.
 ///
-/// [`IETF RFC 791`]: https://tools.ietf.org/html/rfc791
+/// [IETF RFC 791]: https://tools.ietf.org/html/rfc791
 pub const IPV4_MIN_MTU: usize = 68;
 
 // Masks.
@@ -43,7 +43,7 @@ const ECN: u8 = !DSCP;
 const FLAGS_DF: u16be = u16be(u16::to_be(0b0100_0000_0000_0000));
 const FLAGS_MF: u16be = u16be(u16::to_be(0b0010_0000_0000_0000));
 
-/// Internet Protocol v4 based on [`IETF RFC 791`].
+/// Internet Protocol v4 based on [IETF RFC 791].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -73,11 +73,11 @@ const FLAGS_MF: u16be = u16be(u16::to_be(0b0010_0000_0000_0000));
 ///      the minimum value for a correct header is 5.
 ///
 /// - *DSCP*: (6 bits)
-///      Differentiated services codepoint defined in [`IETF RFC 2474`]. Used to
+///      Differentiated services codepoint defined in [IETF RFC 2474]. Used to
 ///      select the per hop behavior a packet experiences at each node.
 ///
 /// - *ECN*: (2 bits)
-///      Explicit congestion notification codepoint defined in [`IETF RFC 3168`].
+///      Explicit congestion notification codepoint defined in [IETF RFC 3168].
 ///
 /// - *Total Length*: (16 bits)
 ///      Total Length is the length of the datagram, measured in octets,
@@ -139,9 +139,9 @@ const FLAGS_MF: u16be = u16be(u16::to_be(0b0010_0000_0000_0000));
 ///      is their transmission in any particular datagram, not their
 ///      implementation.
 ///
-/// [`IETF RFC 791`]: https://tools.ietf.org/html/rfc791#section-3.1
-/// [`IETF RFC 2474`]: https://tools.ietf.org/html/rfc2474
-/// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
+/// [IETF RFC 791]: https://tools.ietf.org/html/rfc791#section-3.1
+/// [IETF RFC 2474]: https://tools.ietf.org/html/rfc2474
+/// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
 pub struct Ipv4 {
     envelope: Ethernet,
     header: NonNull<Ipv4Header>,

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -20,6 +20,7 @@
 
 use crate::packets::checksum::{self, PseudoHeader};
 use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
+use crate::packets::types::u16be;
 use crate::packets::{EtherTypes, Ethernet, Internal, Packet, ParseError};
 use crate::{ensure, SizeOf};
 use failure::Fallible;
@@ -39,8 +40,8 @@ pub const IPV4_MIN_MTU: usize = 68;
 // Masks.
 const DSCP: u8 = 0b1111_1100;
 const ECN: u8 = !DSCP;
-const FLAGS_DF: u16 = 0b0100_0000_0000_0000;
-const FLAGS_MF: u16 = 0b0010_0000_0000_0000;
+const FLAGS_DF: u16be = u16be(u16::to_be(0b0100_0000_0000_0000));
+const FLAGS_MF: u16be = u16be(u16::to_be(0b0010_0000_0000_0000));
 
 /// Internet Protocol v4 based on [`IETF RFC 791`].
 ///
@@ -205,68 +206,64 @@ impl Ipv4 {
     /// the header and data.
     #[inline]
     pub fn total_length(&self) -> u16 {
-        u16::from_be(self.header().total_length)
+        self.header().total_length.into()
     }
 
     /// Sets the length of the packet.
     #[inline]
     fn set_total_length(&mut self, total_length: u16) {
-        self.header_mut().total_length = u16::to_be(total_length);
+        self.header_mut().total_length = total_length.into();
     }
 
     /// Returns the identifying value assigned by the sender to aid in
     /// assembling the fragments of a packet.
     #[inline]
     pub fn identification(&self) -> u16 {
-        u16::from_be(self.header().identification)
+        self.header().identification.into()
     }
 
     /// Sets the identifying value.
     #[inline]
     pub fn set_identification(&mut self, identification: u16) {
-        self.header_mut().identification = u16::to_be(identification);
+        self.header_mut().identification = identification.into();
     }
 
     /// Returns a flag indicating whether the packet can be fragmented.
     #[inline]
     pub fn dont_fragment(&self) -> bool {
-        u16::from_be(self.header().flags_to_frag_offset) & FLAGS_DF != 0
+        self.header().flags_to_frag_offset & FLAGS_DF != u16be::MIN
     }
 
     /// Sets the don't fragment flag to indicate that the packet must not
     /// be fragmented.
     #[inline]
     pub fn set_dont_fragment(&mut self) {
-        self.header_mut().flags_to_frag_offset =
-            u16::to_be(u16::from_be(self.header().flags_to_frag_offset) | FLAGS_DF);
+        self.header_mut().flags_to_frag_offset |= FLAGS_DF
     }
 
     /// Unsets the don't fragment flag to indicate that the packet may be
     /// fragmented.
     #[inline]
     pub fn unset_dont_fragment(&mut self) {
-        self.header_mut().flags_to_frag_offset =
-            u16::to_be(u16::from_be(self.header().flags_to_frag_offset) & !FLAGS_DF);
+        self.header_mut().flags_to_frag_offset &= !FLAGS_DF
     }
 
     /// Returns a flag indicating whether there are more fragments.
     #[inline]
     pub fn more_fragments(&self) -> bool {
-        u16::from_be(self.header().flags_to_frag_offset) & FLAGS_MF != 0
+        self.header().flags_to_frag_offset & FLAGS_MF != u16be::MIN
     }
 
     /// Sets the more fragment flag indicating there are more fragments.
     #[inline]
     pub fn set_more_fragments(&mut self) {
-        self.header_mut().flags_to_frag_offset =
-            u16::to_be(u16::from_be(self.header().flags_to_frag_offset) | FLAGS_MF);
+        self.header_mut().flags_to_frag_offset |= FLAGS_MF
     }
 
     /// Unsets the more fragment flag indicating this is the last fragment.
     #[inline]
     pub fn unset_more_fragments(&mut self) {
-        self.header_mut().flags_to_frag_offset =
-            u16::to_be(u16::from_be(self.header().flags_to_frag_offset) & !FLAGS_MF);
+        self.header_mut().flags_to_frag_offset &= !FLAGS_MF
     }
 
     /// Returns an offset indicating where in the datagram this fragment
@@ -274,15 +271,15 @@ impl Ipv4 {
     /// fragment has offset zero.
     #[inline]
     pub fn fragment_offset(&self) -> u16 {
-        u16::from_be(self.header().flags_to_frag_offset) & 0x1fff
+        (self.header().flags_to_frag_offset & u16be::from(0x1fff)).into()
     }
 
     /// Sets the fragment offset.
     #[inline]
     pub fn set_fragment_offset(&mut self, offset: u16) {
-        self.header_mut().flags_to_frag_offset = u16::to_be(
-            (u16::from_be(self.header().flags_to_frag_offset) & 0xe000) | (offset & 0x1fff),
-        );
+        self.header_mut().flags_to_frag_offset = (self.header().flags_to_frag_offset
+            & u16be::from(0xe000))
+            | u16be::from(offset & 0x1fff)
     }
 
     /// Returns the packet's time to live.
@@ -312,13 +309,13 @@ impl Ipv4 {
     /// Returns the checksum.
     #[inline]
     pub fn checksum(&self) -> u16 {
-        u16::from_be(self.header().checksum)
+        self.header().checksum.into()
     }
 
     /// Sets the checksum.
     #[inline]
     fn set_checksum(&mut self, checksum: u16) {
-        self.header_mut().checksum = u16::to_be(checksum);
+        self.header_mut().checksum = checksum.into();
     }
 
     #[inline]
@@ -560,12 +557,12 @@ impl IpPacket for Ipv4 {
 struct Ipv4Header {
     version_ihl: u8,
     dscp_ecn: u8,
-    total_length: u16,
-    identification: u16,
-    flags_to_frag_offset: u16,
+    total_length: u16be,
+    identification: u16be,
+    flags_to_frag_offset: u16be,
     ttl: u8,
     protocol: u8,
-    checksum: u16,
+    checksum: u16be,
     src: Ipv4Addr,
     dst: Ipv4Addr,
 }
@@ -575,12 +572,12 @@ impl Default for Ipv4Header {
         Ipv4Header {
             version_ihl: 0x45,
             dscp_ecn: 0,
-            total_length: 0,
-            identification: 0,
-            flags_to_frag_offset: 0,
+            total_length: u16be::default(),
+            identification: u16be::default(),
+            flags_to_frag_offset: u16be::default(),
             ttl: DEFAULT_IP_TTL,
             protocol: 0,
-            checksum: 0,
+            checksum: u16be::default(),
             src: Ipv4Addr::UNSPECIFIED,
             dst: Ipv4Addr::UNSPECIFIED,
         }
@@ -635,13 +632,23 @@ mod tests {
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let mut ipv4 = ethernet.parse::<Ipv4>().unwrap();
 
+        // Fields
+        ipv4.set_ihl(ipv4.ihl());
+
         // Flags
         assert_eq!(true, ipv4.dont_fragment());
         assert_eq!(false, ipv4.more_fragments());
+
         ipv4.unset_dont_fragment();
         assert_eq!(false, ipv4.dont_fragment());
+        ipv4.set_dont_fragment();
+        assert_eq!(true, ipv4.dont_fragment());
+
         ipv4.set_more_fragments();
         assert_eq!(true, ipv4.more_fragments());
+        ipv4.unset_more_fragments();
+        assert_eq!(false, ipv4.more_fragments());
+
         ipv4.set_fragment_offset(5);
         assert_eq!(5, ipv4.fragment_offset());
 

--- a/core/src/packets/ip/v6/fragment.rs
+++ b/core/src/packets/ip/v6/fragment.rs
@@ -31,7 +31,7 @@ use std::ptr::NonNull;
 const FRAG_OS: u16be = u16be(u16::to_be(!0b111));
 const FLAG_MORE: u16be = u16be(u16::to_be(0b1));
 
-/// IPv6 Fragment Extension packet based on [`IETF RFC 8200`].
+/// IPv6 Fragment Extension packet based on [IETF RFC 8200].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -69,7 +69,7 @@ const FLAG_MORE: u16be = u16be(u16::to_be(0b1));
 /// `push` and `remove` should be used with care. The result is likely not
 /// a valid packet without additional fixes.
 ///
-/// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-4.5
+/// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-4.5
 pub struct Fragment<E: Ipv6Packet> {
     envelope: E,
     header: NonNull<FragmentHeader>,

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -34,9 +34,9 @@ use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
 
-/// The minimum IPv6 MTU defined in [`IETF RFC 2460`].
+/// The minimum IPv6 MTU defined in [IETF RFC 2460].
 ///
-/// [`IETF RFC 2460`]: https://tools.ietf.org/html/rfc2460#section-5
+/// [IETF RFC 2460]: https://tools.ietf.org/html/rfc2460#section-5
 pub const IPV6_MIN_MTU: usize = 1280;
 
 // Masks
@@ -44,7 +44,7 @@ const DSCP: u32be = u32be(u32::to_be(0x0fc0_0000));
 const ECN: u32be = u32be(u32::to_be(0x0030_0000));
 const FLOW: u32be = u32be(u32::to_be(0xfffff));
 
-/// Internet Protocol v6 based on [`IETF RFC 8200`].
+/// Internet Protocol v6 based on [IETF RFC 8200].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -63,11 +63,11 @@ const FLOW: u32be = u32be(u32::to_be(0xfffff));
 /// - *Version*:              4-bit Internet Protocol version number = 6.
 ///
 /// - *DSCP*:                 6-bit Differentiated services codepoint defined
-///                           in [`IETF RFC 2474`]. Used to select the per hop
+///                           in [IETF RFC 2474]. Used to select the per hop
 ///                           behavior a packet experiences at each node.
 ///
 /// - *ECN*:                  2-bit Explicit congestion notification codepoint
-///                           defined in [`IETF RFC 3168`].
+///                           defined in [IETF RFC 3168].
 ///
 /// - *Flow Label*:           20-bit flow label.
 ///
@@ -92,9 +92,9 @@ const FLOW: u32be = u32be(u32::to_be(0xfffff));
 ///                           packet (possibly not the ultimate recipient, if
 ///                           a Routing header is present).
 ///
-/// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-3
-/// [`IETF RFC 2474`]: https://tools.ietf.org/html/rfc2474
-/// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
+/// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-3
+/// [IETF RFC 2474]: https://tools.ietf.org/html/rfc2474
+/// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
 pub struct Ipv6 {
     envelope: Ethernet,
     header: NonNull<Ipv6Header>,

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -27,9 +27,9 @@ use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
 
-/// IPv6 Segment Routing based on [`IETF DRAFT`].
+/// IPv6 Segment Routing based on [IETF DRAFT].
 ///
-/// Routing Headers are defined in [`IETF RFC 8200`]. The Segment Routing
+/// Routing Headers are defined in [IETF RFC 8200]. The Segment Routing
 /// Header has a new Routing Type (suggested value 4) to be assigned by
 /// IANA.
 ///
@@ -77,15 +77,11 @@ use std::ptr::NonNull;
 ///       |U U U U U U U U|
 ///       +-+-+-+-+-+-+-+-+
 ///
-///   - *U*:               Unused and for future use. *MUST* be 0 on transmission
+///   - *U*:               Unused and for future use. MUST be 0 on transmission
 ///                        and ignored on receipt.
 ///
 /// - *Tag*:               Tag a packet as part of a class or group of packets,
 ///                        e.g., packets sharing the same set of properties.
-///                        When tag is not used at source it *MUST* be set to
-///                        zero on transmission. When tag is not used during SRH
-///                        Processing it *SHOULD* be ignored. The allocation and
-///                        use of tag is outside the scope of this document.
 ///
 /// - *Segment List\[n]*:  128 bit IPv6 addresses representing the nth
 ///                        segment in the Segment List.  The Segment List is
@@ -102,8 +98,8 @@ use std::ptr::NonNull;
 ///
 /// TLVs are not supported yet.
 ///
-/// [`IETF Draft`]: https://tools.ietf.org/html/draft-ietf-6man-segment-routing-header-26#section-2
-/// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-4.4
+/// [IETF Draft]: https://tools.ietf.org/html/draft-ietf-6man-segment-routing-header-26#section-2
+/// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-4.4
 pub struct SegmentRouting<E: Ipv6Packet> {
     envelope: E,
     header: NonNull<SegmentRoutingHeader>,
@@ -431,14 +427,14 @@ impl<E: Ipv6Packet> IpPacket for SegmentRouting<E> {
 
     /// Returns the pseudo header.
     ///
-    /// Based on [`IETF RFC 8200`], if the IPv6 packet contains a Routing
+    /// Based on [IETF RFC 8200], if the IPv6 packet contains a Routing
     /// header, the Destination Address used in the pseudo-header is that
     /// of the final destination. At the originating node, that address will
     /// be in the last element of the Routing header; at the recipient(s),
     /// that address will be in the Destination Address field of the IPv6
     /// header.
     ///
-    /// [`IETF RFC 8200`]: https://tools.ietf.org/html/rfc8200#section-8.1
+    /// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-8.1
     #[inline]
     fn pseudo_header(&self, packet_len: u16, protocol: ProtocolNumber) -> PseudoHeader {
         let dst = match self.dst() {

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -19,6 +19,7 @@
 use crate::packets::checksum::PseudoHeader;
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::ip::{IpPacket, ProtocolNumber, ProtocolNumbers};
+use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet, ParseError};
 use crate::{ensure, SizeOf};
 use failure::{Fail, Fallible};
@@ -182,13 +183,13 @@ impl<E: Ipv6Packet> SegmentRouting<E> {
     /// packets.
     #[inline]
     pub fn tag(&self) -> u16 {
-        u16::from_be(self.header().tag)
+        self.header().tag.into()
     }
 
     /// Tags a packet as part of a class or group of packets.
     #[inline]
     pub fn set_tag(&mut self, tag: u16) {
-        self.header_mut().tag = u16::to_be(tag);
+        self.header_mut().tag = tag.into();
     }
 
     /// Returns the segment list.
@@ -494,7 +495,7 @@ struct SegmentRoutingHeader {
     segments_left: u8,
     last_entry: u8,
     flags: u8,
-    tag: u16,
+    tag: u16be,
 }
 
 impl Default for SegmentRoutingHeader {
@@ -506,7 +507,7 @@ impl Default for SegmentRoutingHeader {
             segments_left: 0,
             last_entry: 0,
             flags: 0,
-            tag: 0,
+            tag: u16be::default(),
         }
     }
 }

--- a/core/src/packets/mod.rs
+++ b/core/src/packets/mod.rs
@@ -23,6 +23,7 @@ mod ethernet;
 pub mod icmp;
 pub mod ip;
 mod tcp;
+pub mod types;
 mod udp;
 
 pub use self::ethernet::*;

--- a/core/src/packets/tcp.rs
+++ b/core/src/packets/tcp.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::ip::{Flow, IpPacket, ProtocolNumbers};
+use crate::packets::types::{u16be, u32be};
 use crate::packets::{checksum, Internal, Packet, ParseError};
 use crate::{ensure, SizeOf};
 use failure::Fallible;
@@ -134,49 +135,49 @@ impl<E: IpPacket> Tcp<E> {
     /// Returns the source port.
     #[inline]
     pub fn src_port(&self) -> u16 {
-        u16::from_be(self.header().src_port)
+        self.header().src_port.into()
     }
 
     /// Sets the source port.
     #[inline]
     pub fn set_src_port(&mut self, src_port: u16) {
-        self.header_mut().src_port = u16::to_be(src_port);
+        self.header_mut().src_port = src_port.into();
     }
 
     /// Returns the destination port.
     #[inline]
     pub fn dst_port(&self) -> u16 {
-        u16::from_be(self.header().dst_port)
+        self.header().dst_port.into()
     }
 
     /// Sets the destination port.
     #[inline]
     pub fn set_dst_port(&mut self, dst_port: u16) {
-        self.header_mut().dst_port = u16::to_be(dst_port);
+        self.header_mut().dst_port = dst_port.into();
     }
 
     /// Returns the sequence number.
     #[inline]
     pub fn seq_no(&self) -> u32 {
-        u32::from_be(self.header().seq_no)
+        self.header().seq_no.into()
     }
 
     /// Sets the sequence number.
     #[inline]
     pub fn set_seq_no(&mut self, seq_no: u32) {
-        self.header_mut().seq_no = u32::to_be(seq_no);
+        self.header_mut().seq_no = seq_no.into();
     }
 
     /// Returns the acknowledgment number.
     #[inline]
     pub fn ack_no(&self) -> u32 {
-        u32::from_be(self.header().ack_no)
+        self.header().ack_no.into()
     }
 
     /// Sets the acknowledgment number.
     #[inline]
     pub fn set_ack_no(&mut self, ack_no: u32) {
-        self.header_mut().ack_no = u32::to_be(ack_no);
+        self.header_mut().ack_no = ack_no.into();
     }
 
     /// Returns the number of 32 bit words in the TCP Header. This indicates
@@ -368,37 +369,37 @@ impl<E: IpPacket> Tcp<E> {
     /// Returns the TCP window.
     #[inline]
     pub fn window(&self) -> u16 {
-        u16::from_be(self.header().window)
+        self.header().window.into()
     }
 
     /// Sets the TCP window.
     #[inline]
     pub fn set_window(&mut self, window: u16) {
-        self.header_mut().window = u16::to_be(window);
+        self.header_mut().window = window.into();
     }
 
     /// Returns the checksum.
     #[inline]
     pub fn checksum(&self) -> u16 {
-        u16::from_be(self.header().checksum)
+        self.header().checksum.into()
     }
 
     /// Sets the checksum.
     #[inline]
     fn set_checksum(&mut self, checksum: u16) {
-        self.header_mut().checksum = u16::to_be(checksum);
+        self.header_mut().checksum = checksum.into();
     }
 
     /// Returns the urgent pointer.
     #[inline]
     pub fn urgent_pointer(&self) -> u16 {
-        u16::from_be(self.header().urgent_pointer)
+        self.header().urgent_pointer.into()
     }
 
     /// Sets the urgent pointer.
     #[inline]
     pub fn set_urgent_pointer(&mut self, urgent_pointer: u16) {
-        self.header_mut().urgent_pointer = u16::to_be(urgent_pointer);
+        self.header_mut().urgent_pointer = urgent_pointer.into();
     }
 
     /// Returns the 5-tuple that uniquely identifies a TCP connection.
@@ -604,29 +605,29 @@ impl<E: IpPacket> Packet for Tcp<E> {
 #[derive(Clone, Copy, Debug, SizeOf)]
 #[repr(C, packed)]
 struct TcpHeader {
-    src_port: u16,
-    dst_port: u16,
-    seq_no: u32,
-    ack_no: u32,
+    src_port: u16be,
+    dst_port: u16be,
+    seq_no: u32be,
+    ack_no: u32be,
     offset_to_ns: u8,
     flags: u8,
-    window: u16,
-    checksum: u16,
-    urgent_pointer: u16,
+    window: u16be,
+    checksum: u16be,
+    urgent_pointer: u16be,
 }
 
 impl Default for TcpHeader {
     fn default() -> TcpHeader {
         TcpHeader {
-            src_port: 0,
-            dst_port: 0,
-            seq_no: 0,
-            ack_no: 0,
+            src_port: u16be::default(),
+            dst_port: u16be::default(),
+            seq_no: u32be::default(),
+            ack_no: u32be::default(),
             offset_to_ns: 5 << 4,
             flags: 0,
-            window: 0,
-            checksum: 0,
-            urgent_pointer: 0,
+            window: u16be::default(),
+            checksum: u16be::default(),
+            urgent_pointer: u16be::default(),
         }
     }
 }

--- a/core/src/packets/tcp.rs
+++ b/core/src/packets/tcp.rs
@@ -35,7 +35,7 @@ const RST: u8 = 0b0000_0100;
 const SYN: u8 = 0b0000_0010;
 const FIN: u8 = 0b0000_0001;
 
-/// Transmission Control Protocol packet based on [`IETF RFC 793`].
+/// Transmission Control Protocol packet based on [IETF RFC 793].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -81,9 +81,9 @@ const FIN: u8 = 0b0000_0001;
 ///      integral number of 32 bits long.
 ///
 /// - *Control Bits*: (9 bits) [from left to right]
-///      - NS:   ECN-nonce nonce sum [`IETF RFC 3540`]
-///      - CWR:  Congestion Window Reduced flag [`IETF RFC 3168`]
-///      - ECE:  ECN-Echo flag [`IETF RFC 3168`]
+///      - NS:   ECN-nonce nonce sum [IETF RFC 3540]
+///      - CWR:  Congestion Window Reduced flag [IETF RFC 3168]
+///      - ECE:  ECN-Echo flag [IETF RFC 3168]
 ///      - URG:  Urgent Pointer field significant
 ///      - ACK:  Acknowledgment field significant
 ///      - PSH:  Push Function
@@ -112,9 +112,9 @@ const FIN: u8 = 0b0000_0001;
 ///     multiple of 8 bits in length.  All options are included in the
 ///     checksum.
 ///
-/// [`IETF RFC 793`]: https://tools.ietf.org/html/rfc793#section-3.1
-/// [`IETF RFC 3540`]: https://tools.ietf.org/html/rfc3540
-/// [`IETF RFC 3168`]: https://tools.ietf.org/html/rfc3168
+/// [IETF RFC 793]: https://tools.ietf.org/html/rfc793#section-3.1
+/// [IETF RFC 3540]: https://tools.ietf.org/html/rfc3540
+/// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
 pub struct Tcp<E: IpPacket> {
     envelope: E,
     header: NonNull<TcpHeader>,

--- a/core/src/packets/types.rs
+++ b/core/src/packets/types.rs
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Custom primitive wrapper types for converting data to/from network byte
+//! order.
+
+use std::convert::From;
+use std::fmt;
+use std::ops;
+
+/// Big-endian type for `u16`.
+///
+/// Used to convert packet fields to host byte order on get and network byte
+/// order on set.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(C, packed)]
+pub struct u16be(pub u16);
+
+impl u16be {
+    /// The 16-bit unsigned integer in big-endian order.
+    pub const MIN: u16be = u16be(0);
+}
+
+impl From<u16> for u16be {
+    fn from(item: u16) -> Self {
+        u16be(u16::to_be(item))
+    }
+}
+
+impl From<u16be> for u16 {
+    fn from(item: u16be) -> Self {
+        u16::from_be(item.0)
+    }
+}
+
+impl ops::BitAnd for u16be {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        u16be(self.0 & rhs.0)
+    }
+}
+
+impl ops::BitAndAssign for u16be {
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = Self(self.0 & rhs.0)
+    }
+}
+
+impl ops::BitOr for u16be {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl ops::BitOrAssign for u16be {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = Self(self.0 | rhs.0)
+    }
+}
+
+impl ops::BitXor for u16be {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self {
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl ops::BitXorAssign for u16be {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        *self = Self(self.0 ^ rhs.0)
+    }
+}
+
+impl ops::Not for u16be {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        u16be(!self.0)
+    }
+}
+
+impl fmt::Display for u16be {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let item = self.0;
+        item.fmt(f)
+    }
+}
+
+/// Big-endian type for `u32`.
+///
+/// Used to convert packet fields to host byte order on get and network byte
+/// order on set.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(C, packed)]
+pub struct u32be(pub u32);
+
+impl u32be {
+    /// The 32-bit unsigned integer in big-endian order.
+    pub const MIN: u32be = u32be(0);
+}
+
+impl From<u32> for u32be {
+    fn from(item: u32) -> Self {
+        u32be(u32::to_be(item))
+    }
+}
+
+impl From<u32be> for u32 {
+    fn from(item: u32be) -> Self {
+        u32::from_be(item.0)
+    }
+}
+
+impl ops::BitAnd for u32be {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        u32be(self.0 & rhs.0)
+    }
+}
+
+impl ops::BitAndAssign for u32be {
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = Self(self.0 & rhs.0)
+    }
+}
+
+impl ops::BitOr for u32be {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl ops::BitOrAssign for u32be {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = Self(self.0 | rhs.0)
+    }
+}
+
+impl ops::BitXor for u32be {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self {
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl ops::BitXorAssign for u32be {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        *self = Self(self.0 ^ rhs.0)
+    }
+}
+
+impl ops::Not for u32be {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        u32be(!self.0)
+    }
+}
+
+impl fmt::Display for u32be {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let item = self.0;
+        item.fmt(f)
+    }
+}

--- a/core/src/packets/types.rs
+++ b/core/src/packets/types.rs
@@ -23,7 +23,7 @@ use std::convert::From;
 use std::fmt;
 use std::ops;
 
-/// Big-endian type for `u16`.
+/// The 16-bit unsigned integer in big-endian order.
 ///
 /// Used to convert packet fields to host byte order on get and network byte
 /// order on set.
@@ -33,7 +33,7 @@ use std::ops;
 pub struct u16be(pub u16);
 
 impl u16be {
-    /// The 16-bit unsigned integer in big-endian order.
+    /// The smallest value that can be represented by this integer type.
     pub const MIN: u16be = u16be(0);
 }
 
@@ -107,7 +107,7 @@ impl fmt::Display for u16be {
     }
 }
 
-/// Big-endian type for `u32`.
+/// The 32-bit unsigned integer in big-endian order.
 ///
 /// Used to convert packet fields to host byte order on get and network byte
 /// order on set.
@@ -117,7 +117,7 @@ impl fmt::Display for u16be {
 pub struct u32be(pub u32);
 
 impl u32be {
-    /// The 32-bit unsigned integer in big-endian order.
+    /// The smallest value that can be represented by this integer type.
     pub const MIN: u32be = u32be(0);
 }
 

--- a/core/src/packets/udp.rs
+++ b/core/src/packets/udp.rs
@@ -17,6 +17,7 @@
 */
 
 use crate::packets::ip::{Flow, IpPacket, ProtocolNumbers};
+use crate::packets::types::u16be;
 use crate::packets::{checksum, Internal, Packet, ParseError};
 use crate::{ensure, SizeOf};
 use failure::Fallible;
@@ -90,43 +91,43 @@ impl<E: IpPacket> Udp<E> {
     /// Returns the source port.
     #[inline]
     pub fn src_port(&self) -> u16 {
-        u16::from_be(self.header().src_port)
+        self.header().src_port.into()
     }
 
     /// Sets the source port.
     #[inline]
     pub fn set_src_port(&mut self, src_port: u16) {
-        self.header_mut().src_port = u16::to_be(src_port);
+        self.header_mut().src_port = src_port.into();
     }
 
     /// Returns the destination port.
     #[inline]
     pub fn dst_port(&self) -> u16 {
-        u16::from_be(self.header().dst_port)
+        self.header().dst_port.into()
     }
 
     /// Sets the destination port.
     #[inline]
     pub fn set_dst_port(&mut self, dst_port: u16) {
-        self.header_mut().dst_port = u16::to_be(dst_port);
+        self.header_mut().dst_port = dst_port.into();
     }
 
     /// Returns the length in octets of this user datagram including this
     /// header and the data.
     #[inline]
     pub fn length(&self) -> u16 {
-        u16::from_be(self.header().length)
+        self.header().length.into()
     }
 
     #[inline]
     fn set_length(&mut self, length: u16) {
-        self.header_mut().length = u16::to_be(length);
+        self.header_mut().length = length.into()
     }
 
     /// Returns the checksum.
     #[inline]
     pub fn checksum(&self) -> u16 {
-        u16::from_be(self.header().checksum)
+        self.header().checksum.into()
     }
 
     /// Sets the checksum.
@@ -137,15 +138,15 @@ impl<E: IpPacket> Udp<E> {
         // transmitter generated no checksum. To set the checksum value to
         // `0`, use `no_checksum` instead of `set_checksum`.
         self.header_mut().checksum = match checksum {
-            0 => 0xFFFF,
-            _ => u16::to_be(checksum),
+            0 => u16be::from(0xFFFF),
+            _ => checksum.into(),
         }
     }
 
     /// Sets checksum to 0 indicating no checksum generated.
     #[inline]
     pub fn no_checksum(&mut self) {
-        self.header_mut().checksum = 0;
+        self.header_mut().checksum = u16be::default();
     }
 
     /// Returns the 5-tuple that uniquely identifies a UDP connection.
@@ -339,10 +340,10 @@ impl<E: IpPacket> Packet for Udp<E> {
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C)]
 struct UdpHeader {
-    src_port: u16,
-    dst_port: u16,
-    length: u16,
-    checksum: u16,
+    src_port: u16be,
+    dst_port: u16be,
+    length: u16be,
+    checksum: u16be,
 }
 
 #[cfg(test)]

--- a/core/src/packets/udp.rs
+++ b/core/src/packets/udp.rs
@@ -25,7 +25,7 @@ use std::fmt;
 use std::net::IpAddr;
 use std::ptr::NonNull;
 
-/// User Datagram Protocol packet based on [`IETF RFC 768`].
+/// User Datagram Protocol packet based on [IETF RFC 768].
 ///
 /// ```
 ///  0                   1                   2                   3
@@ -41,7 +41,7 @@ use std::ptr::NonNull;
 ///
 /// - *Source Port*: (16 bits)
 ///      An  optional field that, when meaningful, indicates the port
-///      of the sending  process, and may be assumed to be the port to which a
+///      of the sending process, and may be assumed to be the port to which a
 ///      reply should be addressed in the absence of any other information. If
 ///      not used, a value of zero is inserted.
 ///
@@ -51,7 +51,7 @@ use std::ptr::NonNull;
 ///
 /// - *Length*: (16 bits)
 ///      The length  in octets of this user datagram including its
-///      header and the data. (This  means the minimum value of the length is
+///      header and the data. (This means the minimum value of the length is
 ///      eight.)
 ///
 /// - *Checksum*: (16 bits)
@@ -60,17 +60,12 @@ use std::ptr::NonNull;
 ///      the data, padded with zero octets at the end (if necessary) to make a
 ///      multiple of two octets.
 ///
-///      The pseudo  header conceptually prefixed to the UDP header contains the
-///      source address,  the destination address, the protocol, and the UDP
+///      The pseudo header conceptually prefixed to the UDP header contains the
+///      source address, the destination address, the protocol, and the UDP
 ///      length. This information gives protection against misrouted datagrams.
 ///      This checksum procedure is the same as is used in TCP.
 ///
-///      If the computed  checksum  is zero,  it is transmitted  as all ones (the
-///      equivalent  in one's complement  arithmetic).   An all zero  transmitted
-///      checksum  value means that the transmitter  generated  no checksum  (for
-///      debugging or for higher level protocols that don't care).
-///
-/// [`IETF RFC 768`]: https://tools.ietf.org/html/rfc768
+/// [IETF RFC 768]: https://tools.ietf.org/html/rfc768
 pub struct Udp<E: IpPacket> {
     envelope: E,
     header: NonNull<UdpHeader>,

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -38,9 +38,9 @@ use tokio_net::driver;
 use tokio_net::signal::unix::{self, SignalKind};
 use tokio_timer::{timer, Interval};
 
-/// Supported [`Unix signals`].
+/// Supported [Unix signals].
 ///
-/// [`Unix signals`]: https://en.wikipedia.org/wiki/Signal_(IPC)#POSIX_signals
+/// [Unix signals]: https://en.wikipedia.org/wiki/Signal_(IPC)#POSIX_signals
 #[derive(Copy, Clone, Debug)]
 pub enum UnixSignal {
     /// This signal is sent to a process when its controlling terminal is closed.

--- a/core/src/testils/criterion.rs
+++ b/core/src/testils/criterion.rs
@@ -16,10 +16,10 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-//! Iterator extensions to [`criterion`], leveraging proptest strategy
+//! Iterator extensions to [criterion], leveraging proptest strategy
 //! generators.
 //!
-//! [`criterion`]: https://crates.io/crates/criterion
+//! [criterion]: https://crates.io/crates/criterion
 
 use super::Rvg;
 use crate::batch::{Batch, PacketTx, Poll};
@@ -34,10 +34,10 @@ use std::time::{Duration, Instant};
 pub trait BencherExt {
     /// Times a `routine` with an input generated via a `proptest strategy`
     /// batch of input, and then times the iteration of the benchmark over the
-    /// input. See [`BatchSize`] for details on choosing the batch size. The
+    /// input. See [BatchSize] for details on choosing the batch size. The
     /// routine consumes its input.
     ///
-    /// [`BatchSize`]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
+    /// [BatchSize]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
     fn iter_proptest_batched<R, S, O>(&mut self, strategy: S, routine: R, batch_size: usize)
     where
         R: FnMut(S::Value) -> O,
@@ -46,9 +46,9 @@ pub trait BencherExt {
     /// Times a `routine` with an input generated via a `proptest strategy`
     /// batch of input that can be polled for benchmarking,
     /// [`pipeline combinators`] and then times the iteration of the benchmark
-    /// over the input. See [`BatchSize`] for details on choosing the batch size.
+    /// over the input. See [BatchSize] for details on choosing the batch size.
     ///
-    /// [`BatchSize`]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
+    /// [BatchSize]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
     /// [`pipeline combinators`]: crate::batch::Batch
     fn iter_proptest_combinators<R, S, O>(&mut self, strategy: S, routine: R, batch_size: usize)
     where

--- a/core/src/testils/criterion.rs
+++ b/core/src/testils/criterion.rs
@@ -34,22 +34,22 @@ use std::time::{Duration, Instant};
 pub trait BencherExt {
     /// Times a `routine` with an input generated via a `proptest strategy`
     /// batch of input, and then times the iteration of the benchmark over the
-    /// input. See [BatchSize] for details on choosing the batch size. The
+    /// input. See [`BatchSize`] for details on choosing the batch size. The
     /// routine consumes its input.
     ///
-    /// [BatchSize]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
+    /// [`BatchSize`]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
     fn iter_proptest_batched<R, S, O>(&mut self, strategy: S, routine: R, batch_size: usize)
     where
         R: FnMut(S::Value) -> O,
         S: Strategy;
 
     /// Times a `routine` with an input generated via a `proptest strategy`
-    /// batch of input that can be polled for benchmarking,
-    /// [`pipeline combinators`] and then times the iteration of the benchmark
-    /// over the input. See [BatchSize] for details on choosing the batch size.
+    /// batch of input that can be polled for benchmarking pipeline combinators
+    /// in [`Batch`] and then times the iteration of the benchmark
+    /// over the input. See [`BatchSize`] for details on choosing the batch size.
     ///
-    /// [BatchSize]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
-    /// [`pipeline combinators`]: crate::batch::Batch
+    /// [`BatchSize`]: https://docs.rs/criterion/latest/criterion/enum.BatchSize.html
+    /// [`Batch`]: crate::batch::Batch
     fn iter_proptest_combinators<R, S, O>(&mut self, strategy: S, routine: R, batch_size: usize)
     where
         R: FnMut(Poll<Receiver<Mbuf>>) -> O,

--- a/core/src/testils/proptest/mod.rs
+++ b/core/src/testils/proptest/mod.rs
@@ -16,12 +16,12 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-//! Defines extended [`proptest`] [`Arbitrary`] traits and [`Strategies`] for
+//! Defines extended [proptest] [Arbitrary] traits and [Strategies] for
 //! packet generation and manipulation for testing and benchmarking purposes.
 //!
-//! [`proptest`]: https://github.com/altsysrq/proptest
-//! [`Arbitrary`]: https://docs.rs/proptest/*/proptest/arbitrary/index.html
-//! [`Strategies`]: https://docs.rs/proptest/*/proptest/strategy/trait.Strategy.html
+//! [proptest]: https://github.com/altsysrq/proptest
+//! [Arbitrary]: https://docs.rs/proptest/*/proptest/arbitrary/index.html
+//! [Strategies]: https://docs.rs/proptest/*/proptest/strategy/trait.Strategy.html
 
 mod arbitrary;
 mod strategy;

--- a/core/src/testils/proptest/mod.rs
+++ b/core/src/testils/proptest/mod.rs
@@ -16,12 +16,12 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-//! Defines extended [proptest] [Arbitrary] traits and [Strategies] for
+//! Defines extended [proptest] [`Arbitrary`] and [`Strategy`] traits for
 //! packet generation and manipulation for testing and benchmarking purposes.
 //!
 //! [proptest]: https://github.com/altsysrq/proptest
-//! [Arbitrary]: https://docs.rs/proptest/*/proptest/arbitrary/index.html
-//! [Strategies]: https://docs.rs/proptest/*/proptest/strategy/trait.Strategy.html
+//! [`Arbitrary`]: https://docs.rs/proptest/latest/proptest/arbitrary/trait.Arbitrary.html
+//! [`Strategy`]: https://docs.rs/proptest/latest/proptest/strategy/trait.Strategy.html
 
 mod arbitrary;
 mod strategy;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -16,9 +16,9 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-//! FFI bindings for [`Capsule`].
+//! FFI bindings for [Capsule].
 //!
-//! [`Capsule`]: https://crates.io/crates/capsule
+//! [Capsule]: https://crates.io/crates/capsule
 
 #![allow(clippy::all)]
 #![allow(dead_code)]


### PR DESCRIPTION
## Description

"new" types to ensure proper conversion of packet data to/from network byte order.

Includes:

- impls bit and/or/xor/*assign and not (!) for types
- includes updates throughout the packets module to use these types
- added flag tests

**Notes**:

- currently includes #94 and will be rebased accordingly after that one is reviewed/merged. 

## Checklist

- [X] Associated tests
- [X] Associated documentation
