### PR TITLE
Make pcap-dump feature use dpdk rx/tx callback

### DIFF
--- a/core/src/dpdk/stats.rs
+++ b/core/src/dpdk/stats.rs
@@ -17,6 +17,7 @@
 */
 
 use super::{Mempool, Port, PortId};
+use crate::dpdk::DpdkError;
 use crate::ffi::{self, AsStr, ToResult};
 use crate::metrics::{labels, Key, Measurement};
 use failure::Fallible;
@@ -60,7 +61,7 @@ impl PortStats {
     pub(crate) fn collect(&self) -> Fallible<Vec<(Key, Measurement)>> {
         let mut stats = ffi::rte_eth_stats::default();
         unsafe {
-            ffi::rte_eth_stats_get(self.id.raw(), &mut stats).to_result()?;
+            ffi::rte_eth_stats_get(self.id.raw(), &mut stats).to_result(DpdkError::from_errno)?;
         }
 
         let mut values = Vec::new();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,6 +62,8 @@
 //! capsule = "0.1"
 //! ```
 //!
+//! ### Using features
+//!
 //! To enable test/bench features for example, you can include Capsule in your
 //! Cargo dependencies with the `testils` feature flag:
 //!
@@ -70,11 +72,19 @@
 //! capsule = { version = "0.1", features = ["testils"] }
 //! ```
 //!
+//! Or, to enable the capturing of port traffic to `pcap` files
+//! automatically per-port, per-core, you can run a Capsule application with the
+//! `pcap-dump` feature flag turned on:
+//!
+//! ```shell
+//! cargo run --features capsule/pcap-dump -- -f capsule-app.toml
+//! ```
+//!
 //! ## Feature flags
 //!
 //! - `default`: Enables metrics by default.
 //! - `metrics`: Enables automatic [`metrics`] collection.
-//! - `pcap-dump`: Enables capturing port traffic to (.pcap) files.
+//! - `pcap-dump`: Enables capturing port traffic to `pcap` files.
 //! - `testils`: Enables utilities for unit testing and benchmarking.
 //! - `full`: Enables all features.
 //!


### PR DESCRIPTION
- minimizes feature-flag configuration attributes for pcap-dump
- adds new AsStr/ToResult impls for ffi/lib conversions
- cleans up function call usage and consistent formatting
- leverages callback user_param to pass port name for pcap create/append

## Type of change
- [X] Cleanup

## Checklist

- [X] Associated tests
- [X] Associated documentation
