### PR TITLE
icmpv4 time exceeded message

### DIFF
--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -20,9 +20,11 @@
 
 mod echo_reply;
 mod echo_request;
+mod time_exceeded;
 
 pub use self::echo_reply::*;
 pub use self::echo_request::*;
+pub use self::time_exceeded::*;
 pub use capsule_macros::Icmpv4Packet;
 
 use crate::packets::ip::v4::Ipv4;
@@ -276,6 +278,11 @@ pub mod Icmpv4Types {
     ///
     /// [Echo Reply]: crate::packets::icmp::v4::EchoReply
     pub const EchoReply: Icmpv4Type = Icmpv4Type(0);
+
+    /// Message type for [Time Exceeded].
+    ///
+    /// [Time Exceeded]: crate::packets::icmp::v4::TimeExceeded
+    pub const TimeExceeded: Icmpv4Type = Icmpv4Type(11);
 }
 
 impl fmt::Display for Icmpv4Type {
@@ -286,6 +293,7 @@ impl fmt::Display for Icmpv4Type {
             match *self {
                 Icmpv4Types::EchoRequest => "Echo Request".to_string(),
                 Icmpv4Types::EchoReply => "Echo Reply".to_string(),
+                Icmpv4Types::TimeExceeded => "Time Exceeded".to_string(),
                 _ => format!("{}", self.0),
             }
         )

--- a/core/src/packets/icmp/v4/time_exceeded.rs
+++ b/core/src/packets/icmp/v4/time_exceeded.rs
@@ -16,8 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-use crate::packets::icmp::v6::{Icmpv6, Icmpv6Message, Icmpv6Packet, Icmpv6Type, Icmpv6Types};
-use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
+use crate::packets::icmp::v4::{Icmpv4, Icmpv4Message, Icmpv4Packet, Icmpv4Type, Icmpv4Types};
+use crate::packets::ip::v4::IPV4_MIN_MTU;
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
@@ -25,36 +25,47 @@ use failure::Fallible;
 use std::fmt;
 use std::ptr::NonNull;
 
-/// Time Exceeded Message defined in [IETF RFC 4443].
+/// Time Exceeded Message defined in [IETF RFC 792].
 ///
 /// ```
-/// 0                   1                   2                   3
-/// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+///  0                   1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |     Type      |     Code      |          Checksum             |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// |                             Unused                            |
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-/// |                    As much of invoking packet                 |
-/// +               as possible without the ICMPv6 packet           +
-/// |               exceeding the minimum IPv6 MTU [IPv6]           |
+/// |    Internet Header + 64 bits of Original Data Datagram        |
 /// ```
 ///
-/// [IETF RFC 4443]: https://tools.ietf.org/html/rfc4443#section-3.3
-#[derive(Icmpv6Packet)]
-pub struct TimeExceeded<E: Ipv6Packet> {
-    icmp: Icmpv6<E>,
+/// [IETF RFC 792]: https://tools.ietf.org/html/rfc792
+#[derive(Icmpv4Packet)]
+pub struct TimeExceeded {
+    icmp: Icmpv4,
     body: NonNull<TimeExceededBody>,
 }
 
-impl<E: Ipv6Packet> TimeExceeded<E> {
+impl TimeExceeded {
+    /// Returns the offset where the data field in the message body starts.
+    #[inline]
+    fn data_offset(&self) -> usize {
+        self.payload_offset() + TimeExceededBody::size_of()
+    }
+
+    /// Returns the length of the data field in the message body.
+    #[inline]
+    fn data_len(&self) -> usize {
+        self.payload_len() - TimeExceededBody::size_of()
+    }
+
     /// Returns the invoking packet as a `u8` slice.
     #[inline]
     pub fn data(&self) -> &[u8] {
-        let offset = self.payload_offset() + TimeExceededBody::size_of();
-        let len = self.payload_len() - TimeExceededBody::size_of();
-
-        if let Ok(data) = self.icmp().mbuf().read_data_slice(offset, len) {
+        if let Ok(data) = self
+            .icmp()
+            .mbuf()
+            .read_data_slice(self.data_offset(), self.data_len())
+        {
             unsafe { &*data.as_ptr() }
         } else {
             &[]
@@ -62,7 +73,7 @@ impl<E: Ipv6Packet> TimeExceeded<E> {
     }
 }
 
-impl<E: Ipv6Packet> fmt::Debug for TimeExceeded<E> {
+impl fmt::Debug for TimeExceeded {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TimeExceeded")
             .field("type", &format!("{}", self.msg_type()))
@@ -75,26 +86,24 @@ impl<E: Ipv6Packet> fmt::Debug for TimeExceeded<E> {
     }
 }
 
-impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
-    type Envelope = E;
-
+impl Icmpv4Message for TimeExceeded {
     #[inline]
-    fn msg_type() -> Icmpv6Type {
-        Icmpv6Types::TimeExceeded
+    fn msg_type() -> Icmpv4Type {
+        Icmpv4Types::TimeExceeded
     }
 
     #[inline]
-    fn icmp(&self) -> &Icmpv6<Self::Envelope> {
+    fn icmp(&self) -> &Icmpv4 {
         &self.icmp
     }
 
     #[inline]
-    fn icmp_mut(&mut self) -> &mut Icmpv6<Self::Envelope> {
+    fn icmp_mut(&mut self) -> &mut Icmpv4 {
         &mut self.icmp
     }
 
     #[inline]
-    fn into_icmp(self) -> Icmpv6<Self::Envelope> {
+    fn into_icmp(self) -> Icmpv4 {
         self.icmp
     }
 
@@ -107,7 +116,7 @@ impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
     }
 
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -116,7 +125,7 @@ impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
     }
 
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 
@@ -129,16 +138,23 @@ impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
     /// Reconciles the derivable header fields against the changes made to
     /// the packet.
     ///
-    /// * the whole packet is truncated so it doesn't exceed the [minimum
-    /// IPv6 MTU].
-    /// * [`checksum`] is computed based on the pseudo-header and the
-    /// `TimeExceeded` message.
+    /// * the data field in the message body is trimmed if it exceeds the
+    /// [minimum IPV4 MTU], as we only need enough for port information.
+    /// * [`checksum`] is computed based on the `TimeExceeded` message.
     ///
-    /// [minimum IPv6 MTU]: IPV6_MIN_MTU
-    /// [`checksum`]: Icmpv6Packet::checksum
+    /// [minimum IPv4 MTU]: IPV4_MIN_MTU
+    /// [`checksum`]: Icmpv4::checksum
     #[inline]
     fn reconcile(&mut self) {
-        let _ = self.envelope_mut().truncate(IPV6_MIN_MTU);
+        let len = self.data_len();
+        let offset = self.data_offset();
+
+        if len > IPV4_MIN_MTU {
+            let _ = self
+                .mbuf_mut()
+                .shrink(offset + IPV4_MIN_MTU, len - IPV4_MIN_MTU);
+        }
+
         self.icmp_mut().compute_checksum();
     }
 }
@@ -152,9 +168,9 @@ struct TimeExceededBody {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packets::ip::v6::Ipv6;
+    use crate::packets::ip::v4::Ipv4;
     use crate::packets::Ethernet;
-    use crate::testils::byte_arrays::IPV6_TCP_PACKET;
+    use crate::testils::byte_arrays::IPV4_TCP_PACKET;
     use crate::Mbuf;
 
     #[test]
@@ -164,19 +180,19 @@ mod tests {
 
     #[capsule::test]
     fn push_and_set_time_exceeded() {
-        let packet = Mbuf::from_bytes(&IPV6_TCP_PACKET).unwrap();
+        let packet = Mbuf::from_bytes(&IPV4_TCP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
-        let ipv6 = ethernet.parse::<Ipv6>().unwrap();
-        let tcp_len = ipv6.payload_len();
+        let ipv4 = ethernet.parse::<Ipv4>().unwrap();
+        let tcp_len = ipv4.payload_len();
 
-        let mut exceeded = ipv6.push::<TimeExceeded<Ipv6>>().unwrap();
+        let mut exceeded = ipv4.push::<TimeExceeded>().unwrap();
 
         assert_eq!(4, exceeded.header_len());
         assert_eq!(
             TimeExceededBody::size_of() + tcp_len,
             exceeded.payload_len()
         );
-        assert_eq!(Icmpv6Types::TimeExceeded, exceeded.msg_type());
+        assert_eq!(Icmpv4Types::TimeExceeded, exceeded.msg_type());
         assert_eq!(0, exceeded.code());
         assert_eq!(tcp_len, exceeded.data().len());
 
@@ -188,19 +204,28 @@ mod tests {
     }
 
     #[capsule::test]
-    fn truncate_to_ipv6_min_mtu() {
-        // starts with a buffer larger than min MTU.
-        let packet = Mbuf::from_bytes(&[42; 1600]).unwrap();
+    fn shrinks_to_ipv4_min_mtu() {
+        // starts with a buffer with a message body larger than min MTU.
+        let packet = Mbuf::from_bytes(&[42; 100]).unwrap();
         let ethernet = packet.push::<Ethernet>().unwrap();
-        let ipv6 = ethernet.push::<Ipv6>().unwrap();
-
-        // the max packet len is MTU + Ethernet header
-        let max_len = IPV6_MIN_MTU + 14;
-
-        let mut exceeded = ipv6.push::<TimeExceeded<Ipv6>>().unwrap();
-        assert!(exceeded.mbuf().data_len() > max_len);
+        let ipv4 = ethernet.push::<Ipv4>().unwrap();
+        let mut exceeded = ipv4.push::<TimeExceeded>().unwrap();
+        assert!(exceeded.data_len() > IPV4_MIN_MTU);
 
         exceeded.reconcile_all();
-        assert_eq!(max_len, exceeded.mbuf().data_len());
+        assert_eq!(IPV4_MIN_MTU, exceeded.data_len());
+    }
+
+    #[capsule::test]
+    fn message_body_no_shrink() {
+        // starts with a buffer with a message body smaller than min MTU.
+        let packet = Mbuf::from_bytes(&[42; 50]).unwrap();
+        let ethernet = packet.push::<Ethernet>().unwrap();
+        let ipv4 = ethernet.push::<Ipv4>().unwrap();
+        let mut exceeded = ipv4.push::<TimeExceeded>().unwrap();
+        assert!(exceeded.data_len() < IPV4_MIN_MTU);
+
+        exceeded.reconcile_all();
+        assert_eq!(50, exceeded.data_len());
     }
 }

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -252,7 +252,7 @@ impl<E: Ipv6Packet> Packet for Icmpv6<E> {
     /// * [`checksum`] is computed based on the [`pseudo-header`] and the
     /// full packet.
     ///
-    /// [`checksum`]: Icmpv6::checksum
+    /// [`checksum`]: Icmpv6Packet::checksum
     /// [`pseudo-header`]: crate::packets::checksum::PseudoHeader
     #[inline]
     fn reconcile(&mut self) {
@@ -412,7 +412,7 @@ pub trait Icmpv6Message {
     /// the packet matches the assigned number before invoking this function.
     ///
     /// [`Icmpv6::downcast`]: Icmpv6::downcast
-    /// [`msg_type`]: Icmpv6::msg_type
+    /// [`msg_type`]: Icmpv6Packet::msg_type
     fn try_parse(icmp: Icmpv6<Self::Envelope>, internal: Internal) -> Fallible<Self>
     where
         Self: Sized;
@@ -429,7 +429,7 @@ pub trait Icmpv6Message {
     /// This function cannot be invoked directly. It is internally used by
     /// [`Packet::push`].
     ///
-    /// [`msg_type`]: Icmpv6::msg_type
+    /// [`msg_type`]: Icmpv6Packet::msg_type
     /// [`Packet::push`]: Packet::push
     fn try_push(icmp: Icmpv6<Self::Envelope>, internal: Internal) -> Fallible<Self>
     where
@@ -439,7 +439,7 @@ pub trait Icmpv6Message {
     /// the packet. The default implementation computes the [`checksum`]
     /// based on the pseudo-header and the ICMPv6 message.
     ///
-    /// [`checksum`]: Icmpv6::checksum
+    /// [`checksum`]: Icmpv6Packet::checksum
     #[inline]
     fn reconcile(&mut self) {
         self.icmp_mut().compute_checksum()

--- a/core/src/packets/icmp/v6/ndp/redirect.rs
+++ b/core/src/packets/icmp/v6/ndp/redirect.rs
@@ -184,7 +184,7 @@ impl<E: Ipv6Packet> Icmpv6Message for Redirect<E> {
     /// is set to account for the original IP header and data.
     ///
     /// [minimum IPv6 MTU]: IPV6_MIN_MTU
-    /// [`checksum`]: Icmpv6::checksum
+    /// [`checksum`]: Icmpv6Packet::checksum
     /// [`RedirectedHeader`]: RedirectedHeader
     #[inline]
     fn reconcile(&mut self) {

--- a/core/src/packets/icmp/v6/too_big.rs
+++ b/core/src/packets/icmp/v6/too_big.rs
@@ -160,7 +160,7 @@ impl<E: Ipv6Packet> Icmpv6Message for PacketTooBig<E> {
     /// `PacketTooBig` message.
     ///
     /// [minimum IPv6 MTU]: IPV6_MIN_MTU
-    /// [`checksum`]: Icmpv6::checksum
+    /// [`checksum`]: Icmpv6Packet::checksum
     #[inline]
     fn reconcile(&mut self) {
         let _ = self.envelope_mut().truncate(IPV6_MIN_MTU);


### PR DESCRIPTION
## Description

Time Exceeded Message defined in [IETF RFC 792] (for ICMPv4). 

Also includes:
- doc fixes for links to private fns


## Type of change

- [X] New protocol
- [X] Documentation update

## Checklist

- [X] Associated tests
- [X] Associated documentation
