### PR TITLE
bump metrics lib to 0.13

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ failure = "0.1"
 futures-preview = "=0.3.0-alpha.19"
 libc = "0.2"
 metrics-core = { version = "0.5", optional = true }
-metrics-runtime = { version = "0.12", optional = true, default-features = false }
+metrics-runtime = { version = "0.13", optional = true, default-features = false }
 once_cell = "1.2"
 proptest = { version = "0.10", optional = true }
 regex = "1"

--- a/examples/kni/Cargo.toml
+++ b/examples/kni/Cargo.toml
@@ -19,6 +19,6 @@ doctest = false
 capsule = { version = "0.1", path = "../../core" }
 failure = "0.1"
 metrics-core = "0.5"
-metrics-runtime = "0.12"
+metrics-observer-yaml = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/kni/main.rs
+++ b/examples/kni/main.rs
@@ -21,7 +21,7 @@ use capsule::metrics;
 use capsule::{batch, Runtime};
 use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
-use metrics_runtime::observers::YamlBuilder;
+use metrics_observer_yaml::YamlBuilder;
 use std::time::Duration;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;

--- a/examples/syn-flood/Cargo.toml
+++ b/examples/syn-flood/Cargo.toml
@@ -19,6 +19,6 @@ doctest = false
 capsule = { version = "0.1", path = "../../core" }
 failure = "0.1"
 metrics-core = "0.5"
-metrics-runtime = "0.12"
+metrics-observer-yaml = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/syn-flood/main.rs
+++ b/examples/syn-flood/main.rs
@@ -24,7 +24,7 @@ use capsule::packets::{Ethernet, Packet, Tcp};
 use capsule::{batch, Mbuf, PortQueue, Runtime};
 use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
-use metrics_runtime::observers::YamlBuilder;
+use metrics_observer_yaml::YamlBuilder;
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::time::Duration;


### PR DESCRIPTION
~Fixes the security advisory failure on [sized-chunks](https://rustsec.org/advisories/RUSTSEC-2020-0041.html).~
