### PR TITLE
introduce tcp and udp aliases

### DIFF
--- a/bench/packets.rs
+++ b/bench/packets.rs
@@ -18,7 +18,7 @@
 
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::ip::v6::{Ipv6, SegmentRouting};
-use capsule::packets::{Ethernet, Packet, Udp};
+use capsule::packets::{Ethernet, Packet, Udp4};
 use capsule::testils::criterion::BencherExt;
 use capsule::testils::proptest::*;
 use capsule::testils::{PacketExt, Rvg};
@@ -30,12 +30,12 @@ use std::net::Ipv6Addr;
 
 const BATCH_SIZE: usize = 500;
 
-fn single_parse_udp(ipv4: Ipv4) -> Udp<Ipv4> {
-    ipv4.parse::<Udp<Ipv4>>().unwrap()
+fn single_parse_udp(ipv4: Ipv4) -> Udp4 {
+    ipv4.parse::<Udp4>().unwrap()
 }
 
 fn single_peek_udp(ipv4: Ipv4) -> Ipv4 {
-    ipv4.peek::<Udp<Ipv4>>().unwrap();
+    ipv4.peek::<Udp4>().unwrap();
     ipv4
 }
 
@@ -62,16 +62,16 @@ fn single_peek_vs_parse(c: &mut Criterion) {
     group.finish()
 }
 
-fn multi_parse_udp(mbuf: Mbuf) -> Udp<Ipv4> {
+fn multi_parse_udp(mbuf: Mbuf) -> Udp4 {
     let ethernet = mbuf.parse::<Ethernet>().unwrap();
     let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-    ipv4.parse::<Udp<Ipv4>>().unwrap()
+    ipv4.parse::<Udp4>().unwrap()
 }
 
 fn multi_peek_udp(mbuf: Mbuf) -> Mbuf {
     let ethernet = mbuf.peek::<Ethernet>().unwrap();
     let ipv4 = ethernet.peek::<Ipv4>().unwrap();
-    ipv4.peek::<Udp<Ipv4>>().unwrap();
+    ipv4.peek::<Udp4>().unwrap();
     mbuf
 }
 
@@ -147,7 +147,7 @@ fn multi_parse_upto_variable_srh(c: &mut Criterion) {
     });
 }
 
-fn deparse_udp(udp: Udp<Ipv4>) -> Mbuf {
+fn deparse_udp(udp: Udp4) -> Mbuf {
     let d_ipv4 = udp.deparse();
     let d_eth = d_ipv4.deparse();
     d_eth.deparse()
@@ -161,7 +161,7 @@ fn deparse(c: &mut Criterion) {
     });
 }
 
-fn reset_udp(udp: Udp<Ipv4>) -> Mbuf {
+fn reset_udp(udp: Udp4) -> Mbuf {
     udp.reset()
 }
 
@@ -173,10 +173,10 @@ fn reset(c: &mut Criterion) {
     });
 }
 
-fn multi_push_udp(mbuf: Mbuf) -> Udp<Ipv4> {
+fn multi_push_udp(mbuf: Mbuf) -> Udp4 {
     let ethernet = mbuf.push::<Ethernet>().unwrap();
     let ipv4 = ethernet.push::<Ipv4>().unwrap();
-    ipv4.push::<Udp<Ipv4>>().unwrap()
+    ipv4.push::<Udp4>().unwrap()
 }
 
 #[capsule::bench(mempool_capacity = 511)]
@@ -187,8 +187,8 @@ fn multi_push(c: &mut Criterion) {
     });
 }
 
-fn single_push_udp(ipv4: Ipv4) -> Udp<Ipv4> {
-    ipv4.push::<Udp<Ipv4>>().unwrap()
+fn single_push_udp(ipv4: Ipv4) -> Udp4 {
+    ipv4.push::<Udp4>().unwrap()
 }
 
 #[capsule::bench(mempool_capacity = 511)]
@@ -202,7 +202,7 @@ fn single_push(c: &mut Criterion) {
     });
 }
 
-fn single_remove_udp(udp: Udp<Ipv4>) -> Ipv4 {
+fn single_remove_udp(udp: Udp4) -> Ipv4 {
     udp.remove().unwrap()
 }
 
@@ -214,7 +214,7 @@ fn single_remove(c: &mut Criterion) {
     });
 }
 
-fn multi_remove_udp(udp: Udp<Ipv4>) -> Mbuf {
+fn multi_remove_udp(udp: Udp4) -> Mbuf {
     let ipv4 = udp.remove().unwrap();
     let ethernet = ipv4.remove().unwrap();
     ethernet.remove().unwrap()

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -513,7 +513,7 @@ mod tests {
     use super::*;
     use crate::packets::ip::v6::Ipv6;
     use crate::packets::ip::ProtocolNumbers;
-    use crate::packets::{Ethernet, Tcp};
+    use crate::packets::{Ethernet, Tcp, Tcp6};
     use crate::testils::byte_arrays::{IPV6_TCP_PACKET, SR_TCP_PACKET};
     use crate::Mbuf;
 
@@ -681,7 +681,7 @@ mod tests {
         assert_eq!(ProtocolNumbers::Tcp, ipv6.next_header());
 
         // make sure rest of the packet still valid
-        let tcp = ipv6.parse::<Tcp<Ipv6>>().unwrap();
+        let tcp = ipv6.parse::<Tcp6>().unwrap();
         assert_eq!(3464, tcp.src_port());
     }
 }

--- a/core/src/packets/mod.rs
+++ b/core/src/packets/mod.rs
@@ -61,7 +61,7 @@ pub struct Internal(());
 /// let ethernet = packet.push::<Ethernet>()?;
 /// let ipv4 = ethernet.push::<Ipv4>()?;
 ///
-/// let mut tcp = ipv4.push::<Tcp<Ipv4>>()?;
+/// let mut tcp = ipv4.push::<Tcp4>()?;
 /// tcp.set_dst_ip(remote_ip);
 /// tcp.set_dst_port(22);
 /// tcp.reconcile_all();
@@ -338,7 +338,6 @@ mod tests {
     use super::*;
     use crate::net::MacAddr;
     use crate::packets::ip::v4::Ipv4;
-    use crate::packets::Udp;
     use crate::testils::byte_arrays::IPV4_UDP_PACKET;
 
     #[capsule::test]
@@ -348,7 +347,7 @@ mod tests {
 
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let udp = ipv4.parse::<Udp4>().unwrap();
         let reset = udp.reset();
 
         assert_eq!(len, reset.data_len());
@@ -362,7 +361,7 @@ mod tests {
         assert_eq!(MacAddr::new(0, 0, 0, 0, 0, 2), ethernet.src());
         let v4 = ethernet.peek::<Ipv4>().unwrap();
         assert_eq!(255, v4.ttl());
-        let udp = v4.peek::<Udp<Ipv4>>().unwrap();
+        let udp = v4.peek::<Udp4>().unwrap();
         assert_eq!(39376, udp.src_port());
     }
 
@@ -371,10 +370,10 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let v4 = ethernet.parse::<Ipv4>().unwrap();
-        let udp = v4.parse::<Udp<Ipv4>>().unwrap();
+        let udp = v4.parse::<Udp4>().unwrap();
         let mut v4_2 = udp.deparse();
         v4_2.set_ttl(25);
-        let udp_2 = v4_2.parse::<Udp<Ipv4>>().unwrap();
+        let udp_2 = v4_2.parse::<Udp4>().unwrap();
         let v4_4 = udp_2.envelope();
         assert_eq!(v4_4.ttl(), 25);
     }
@@ -385,7 +384,7 @@ mod tests {
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let v4 = ethernet.parse::<Ipv4>().unwrap();
 
-        let mut udp = v4.parse::<Udp<Ipv4>>().unwrap();
+        let mut udp = v4.parse::<Udp4>().unwrap();
         assert!(udp.payload_len() > 0);
 
         let _ = udp.remove_payload();

--- a/core/src/packets/tcp.rs
+++ b/core/src/packets/tcp.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use crate::packets::ip::v4::Ipv4;
+use crate::packets::ip::v6::Ipv6;
 use crate::packets::ip::{Flow, IpPacket, ProtocolNumbers};
 use crate::packets::types::{u16be, u32be};
 use crate::packets::{checksum, Internal, Packet, ParseError};
@@ -598,6 +600,12 @@ impl<E: IpPacket> Packet for Tcp<E> {
     }
 }
 
+/// A type alias for an IPv4 TCP packet.
+pub type Tcp4 = Tcp<Ipv4>;
+
+/// A type alias for an IPv6 TCP packet.
+pub type Tcp6 = Tcp<Ipv6>;
+
 /// TCP header.
 ///
 /// The header only include the fixed portion of the TCP header. Variable
@@ -635,8 +643,7 @@ impl Default for TcpHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packets::ip::v4::Ipv4;
-    use crate::packets::ip::v6::{Ipv6, SegmentRouting};
+    use crate::packets::ip::v6::SegmentRouting;
     use crate::packets::Ethernet;
     use crate::testils::byte_arrays::{IPV4_TCP_PACKET, IPV4_UDP_PACKET, SR_TCP_PACKET};
     use crate::Mbuf;
@@ -652,7 +659,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_TCP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let tcp = ipv4.parse::<Tcp<Ipv4>>().unwrap();
+        let tcp = ipv4.parse::<Tcp4>().unwrap();
 
         assert_eq!(36869, tcp.src_port());
         assert_eq!(23, tcp.dst_port());
@@ -679,7 +686,7 @@ mod tests {
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
 
-        assert!(ipv4.parse::<Tcp<Ipv4>>().is_err());
+        assert!(ipv4.parse::<Tcp4>().is_err());
     }
 
     #[capsule::test]
@@ -687,7 +694,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_TCP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let tcp = ipv4.parse::<Tcp<Ipv4>>().unwrap();
+        let tcp = ipv4.parse::<Tcp4>().unwrap();
         let flow = tcp.flow();
 
         assert_eq!("139.133.217.110", flow.src_ip().to_string());
@@ -718,7 +725,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_TCP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let mut tcp = ipv4.parse::<Tcp<Ipv4>>().unwrap();
+        let mut tcp = ipv4.parse::<Tcp4>().unwrap();
 
         let old_checksum = tcp.checksum();
         let new_ip = Ipv4Addr::new(10, 0, 0, 0);
@@ -741,7 +748,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_TCP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let mut tcp = ipv4.parse::<Tcp<Ipv4>>().unwrap();
+        let mut tcp = ipv4.parse::<Tcp4>().unwrap();
 
         let expected = tcp.checksum();
         // no payload change but force a checksum recompute anyway
@@ -754,7 +761,7 @@ mod tests {
         let packet = Mbuf::new().unwrap();
         let ethernet = packet.push::<Ethernet>().unwrap();
         let ipv4 = ethernet.push::<Ipv4>().unwrap();
-        let tcp = ipv4.push::<Tcp<Ipv4>>().unwrap();
+        let tcp = ipv4.push::<Tcp4>().unwrap();
 
         assert_eq!(TcpHeader::size_of(), tcp.len());
         assert_eq!(5, tcp.data_offset());

--- a/core/src/packets/udp.rs
+++ b/core/src/packets/udp.rs
@@ -16,6 +16,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use crate::packets::ip::v4::Ipv4;
+use crate::packets::ip::v6::Ipv6;
 use crate::packets::ip::{Flow, IpPacket, ProtocolNumbers};
 use crate::packets::types::u16be;
 use crate::packets::{checksum, Internal, Packet, ParseError};
@@ -331,6 +333,12 @@ impl<E: IpPacket> Packet for Udp<E> {
     }
 }
 
+/// A type alias for an IPv4 UDP packet.
+pub type Udp4 = Udp<Ipv4>;
+
+/// A type alias for an IPv6 UDP packet.
+pub type Udp6 = Udp<Ipv6>;
+
 /// UDP header.
 #[derive(Clone, Copy, Debug, Default, SizeOf)]
 #[repr(C)]
@@ -344,7 +352,6 @@ struct UdpHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packets::ip::v4::Ipv4;
     use crate::packets::Ethernet;
     use crate::testils::byte_arrays::{IPV4_TCP_PACKET, IPV4_UDP_PACKET};
     use crate::Mbuf;
@@ -360,7 +367,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let udp = ipv4.parse::<Udp4>().unwrap();
 
         assert_eq!(39376, udp.src_port());
         assert_eq!(1087, udp.dst_port());
@@ -374,7 +381,7 @@ mod tests {
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
 
-        assert!(ipv4.parse::<Udp<Ipv4>>().is_err());
+        assert!(ipv4.parse::<Udp4>().is_err());
     }
 
     #[capsule::test]
@@ -382,7 +389,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let udp = ipv4.parse::<Udp4>().unwrap();
         let flow = udp.flow();
 
         assert_eq!("139.133.217.110", flow.src_ip().to_string());
@@ -397,7 +404,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let mut udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let mut udp = ipv4.parse::<Udp4>().unwrap();
 
         let old_checksum = udp.checksum();
         let new_ip = Ipv4Addr::new(10, 0, 0, 0);
@@ -420,7 +427,7 @@ mod tests {
         let packet = Mbuf::from_bytes(&IPV4_UDP_PACKET).unwrap();
         let ethernet = packet.parse::<Ethernet>().unwrap();
         let ipv4 = ethernet.parse::<Ipv4>().unwrap();
-        let mut udp = ipv4.parse::<Udp<Ipv4>>().unwrap();
+        let mut udp = ipv4.parse::<Udp4>().unwrap();
 
         let expected = udp.checksum();
         // no payload change but force a checksum recompute anyway
@@ -433,7 +440,7 @@ mod tests {
         let packet = Mbuf::new().unwrap();
         let ethernet = packet.push::<Ethernet>().unwrap();
         let ipv4 = ethernet.push::<Ipv4>().unwrap();
-        let udp = ipv4.push::<Udp<Ipv4>>().unwrap();
+        let udp = ipv4.push::<Udp4>().unwrap();
 
         assert_eq!(UdpHeader::size_of(), udp.len());
 

--- a/core/src/testils/packet.rs
+++ b/core/src/testils/packet.rs
@@ -18,7 +18,7 @@
 
 use crate::packets::ip::v4::Ipv4;
 use crate::packets::ip::v6::{Ipv6, SegmentRouting};
-use crate::packets::{Ethernet, Packet, Tcp, Udp};
+use crate::packets::{Ethernet, Packet, Tcp, Tcp4, Tcp6, Udp4, Udp6};
 
 /// [`Packet`] extension trait.
 ///
@@ -39,13 +39,13 @@ pub trait PacketExt: Packet + Sized {
     }
 
     /// Converts the packet into a TCP packet inside IPv4.
-    fn into_v4_tcp(self) -> Tcp<Ipv4> {
-        self.into_v4().parse::<Tcp<Ipv4>>().unwrap()
+    fn into_v4_tcp(self) -> Tcp4 {
+        self.into_v4().parse::<Tcp4>().unwrap()
     }
 
     /// Converts the packet into a UDP packet inside IPv4.
-    fn into_v4_udp(self) -> Udp<Ipv4> {
-        self.into_v4().parse::<Udp<Ipv4>>().unwrap()
+    fn into_v4_udp(self) -> Udp4 {
+        self.into_v4().parse::<Udp4>().unwrap()
     }
 
     /// Converts the packet into an IPv6 packet.
@@ -54,13 +54,13 @@ pub trait PacketExt: Packet + Sized {
     }
 
     /// Converts the packet into a TCP packet inside IPv6.
-    fn into_v6_tcp(self) -> Tcp<Ipv6> {
-        self.into_v6().parse::<Tcp<Ipv6>>().unwrap()
+    fn into_v6_tcp(self) -> Tcp6 {
+        self.into_v6().parse::<Tcp6>().unwrap()
     }
 
     /// Converts the packet into a UDP packet inside IPv6.
-    fn into_v6_udp(self) -> Udp<Ipv6> {
-        self.into_v6().parse::<Udp<Ipv6>>().unwrap()
+    fn into_v6_udp(self) -> Udp6 {
+        self.into_v6().parse::<Udp6>().unwrap()
     }
 
     /// Converts the packet into an IPv6 packet with a SRH extension.

--- a/core/src/testils/proptest/strategy.rs
+++ b/core/src/testils/proptest/strategy.rs
@@ -427,7 +427,7 @@ pub fn v4_tcp() -> impl Strategy<Value = Mbuf> {
 ///         let packet = packet.parse::<Ethernet>().unwrap();
 ///         let v4 = packet.parse::<Ipv4>().unwrap();
 ///         assert_eq!("127.0.0.1".parse(), v4.src());
-///         let tcp = v4.parse::<Tcp<Ipv4>>().unwrap();
+///         let tcp = v4.parse::<Tcp4>().unwrap();
 ///         assert_eq!(80, tcp.dst_port());
 ///     });
 /// }
@@ -465,7 +465,7 @@ pub fn v4_udp() -> impl Strategy<Value = Mbuf> {
 ///         let packet = packet.parse::<Ethernet>().unwrap();
 ///         let v4 = packet.parse::<Ipv4>().unwrap();
 ///         prop_assert_eq!("127.0.0.1".parse(), v4.src());
-///         let udp = v4.parse::<Udp<Ipv4>>().unwrap();
+///         let udp = v4.parse::<Udp4>().unwrap();
 ///         prop_assert_eq!(53, udp.dst_port());
 ///     });
 /// }
@@ -503,7 +503,7 @@ pub fn v6_tcp() -> impl Strategy<Value = Mbuf> {
 ///         let packet = packet.parse::<Ethernet>().unwrap();
 ///         let v6 = packet.parse::<Ipv6>().unwrap();
 ///         prop_assert_eq!("::1".parse(), v6.src());
-///         let tcp = v6.parse::<Tcp<Ipv6>>().unwrap();
+///         let tcp = v6.parse::<Tcp6>().unwrap();
 ///         prop_assert_eq!(80, tcp.dst_port());
 ///     });
 /// }
@@ -541,7 +541,7 @@ pub fn v6_udp() -> impl Strategy<Value = Mbuf> {
 ///         let packet = packet.parse::<Ethernet>().unwrap();
 ///         let v6 = packet.parse::<Ipv6>().unwrap();
 ///         prop_assert_eq!("::1".parse(), v6.src());
-///         let udp = v6.parse::<Udp<Ipv6>>().unwrap();
+///         let udp = v6.parse::<Udp6>().unwrap();
 ///         prop_assert_eq!(53, udp.dst_port());
 ///     });
 /// }

--- a/examples/pktdump/main.rs
+++ b/examples/pktdump/main.rs
@@ -21,7 +21,7 @@ use capsule::config::load_config;
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::ip::v6::Ipv6;
 use capsule::packets::ip::IpPacket;
-use capsule::packets::{EtherTypes, Ethernet, Packet, Tcp};
+use capsule::packets::{EtherTypes, Ethernet, Packet, Tcp, Tcp4, Tcp6};
 use capsule::{compose, Mbuf, PortQueue, Runtime};
 use colored::*;
 use failure::Fallible;
@@ -44,7 +44,7 @@ fn dump_v4(ethernet: &Ethernet) -> Fallible<()> {
     let info_fmt = format!("{:?}", v4).yellow();
     println!("{}", info_fmt);
 
-    let tcp = v4.peek::<Tcp<Ipv4>>()?;
+    let tcp = v4.peek::<Tcp4>()?;
     dump_tcp(&tcp);
 
     Ok(())
@@ -56,7 +56,7 @@ fn dump_v6(ethernet: &Ethernet) -> Fallible<()> {
     let info_fmt = format!("{:?}", v6).cyan();
     println!("{}", info_fmt);
 
-    let tcp = v6.peek::<Tcp<Ipv6>>()?;
+    let tcp = v6.peek::<Tcp6>()?;
     dump_tcp(&tcp);
 
     Ok(())

--- a/examples/syn-flood/main.rs
+++ b/examples/syn-flood/main.rs
@@ -20,7 +20,7 @@ use capsule::batch::{Batch, Pipeline};
 use capsule::config::load_config;
 use capsule::metrics;
 use capsule::packets::ip::v4::Ipv4;
-use capsule::packets::{Ethernet, Packet, Tcp};
+use capsule::packets::{Ethernet, Packet, Tcp4};
 use capsule::{batch, Mbuf, PortQueue, Runtime};
 use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
@@ -55,7 +55,7 @@ fn install(qs: HashMap<String, PortQueue>) -> impl Pipeline {
         v4.set_src(next_ip.into());
         v4.set_dst(localhost);
 
-        let mut tcp = v4.push::<Tcp<Ipv4>>()?;
+        let mut tcp = v4.push::<Tcp4>()?;
         tcp.set_syn();
         tcp.set_seq_no(1);
         tcp.set_window(10);


### PR DESCRIPTION
## Description

A small quality of life improvement by introducing a couple `Tcp` and `Udp` aliases. Instead of writing

```
let udp = packet.parse::<Tcp<Ipv4>>()?;
```

you can now write

```
let udp = packet.parse::<Tcp4>()?;
```

## Type of change

- [x] New feature