### PR TITLE
change criterion report location

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
         continue-on-error: true
 
   bench:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     runs-on: ubuntu-18.04
 
     container:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: criterion-report
-          path: ./bench/target/criterion
+          path: ./target/criterion
         continue-on-error: true
 
       - name: slack-it
@@ -125,7 +125,7 @@ jobs:
         continue-on-error: true
 
   bench:
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-18.04
 
     container:
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: criterion-report
-          path: ./bench/target/criterion
+          path: ./target/criterion
 
       - name: slack-it
         uses: homoluctus/slatify@v2.1.2


### PR DESCRIPTION
## Description

Fixes the broken `bench` job. The location of the Criterion report seems to have changed from `./bench/target/criterion` to `./target/criterion`.

## Type of change

- [x] Bug fix