### PR TITLE
migrate from failure to anyhow + thiserror

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -10,9 +10,9 @@ Benchmarks for Capsule.
 """
 
 [dev-dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../core", features = ["testils"] }
 criterion = "0.3"
-failure = "0.1"
 proptest = "0.10"
 
 [[bench]]

--- a/bench/combinators.rs
+++ b/bench/combinators.rs
@@ -16,6 +16,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::batch::{Batch, Either};
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::{Ethernet, Packet};
@@ -23,7 +24,6 @@ use capsule::testils::criterion::BencherExt;
 use capsule::testils::proptest::*;
 use capsule::{compose, Mbuf};
 use criterion::{criterion_group, criterion_main, Criterion};
-use failure::Fallible;
 use proptest::prelude::*;
 use proptest::strategy;
 
@@ -86,7 +86,7 @@ fn map(batch: impl Batch<Item = Mbuf>) -> impl Batch<Item = Ethernet> {
     batch.map(|p| p.parse::<Ethernet>())
 }
 
-fn no_batch_map(mbuf: Mbuf) -> Fallible<Ethernet> {
+fn no_batch_map(mbuf: Mbuf) -> Result<Ethernet> {
     mbuf.parse::<Ethernet>()
 }
 
@@ -189,7 +189,7 @@ fn replace(batch: impl Batch<Item = Mbuf>) -> impl Batch<Item = Mbuf> {
     batch.replace(|_p| Mbuf::new())
 }
 
-fn no_batch_replace(_mbuf: Mbuf) -> Fallible<Mbuf> {
+fn no_batch_replace(_mbuf: Mbuf) -> Result<Mbuf> {
     Mbuf::new()
 }
 

--- a/bench/mbuf.rs
+++ b/bench/mbuf.rs
@@ -16,19 +16,19 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::Mbuf;
 use criterion::{criterion_group, criterion_main, Criterion};
-use failure::Fallible;
 
 const BATCH_SIZE: usize = 100;
 
-fn alloc() -> Fallible<Vec<Mbuf>> {
+fn alloc() -> Result<Vec<Mbuf>> {
     (0..BATCH_SIZE)
         .map(|_| Mbuf::new())
-        .collect::<Fallible<Vec<Mbuf>>>()
+        .collect::<Result<Vec<Mbuf>>>()
 }
 
-fn alloc_bulk() -> Fallible<Vec<Mbuf>> {
+fn alloc_bulk() -> Result<Vec<Mbuf>> {
     Mbuf::alloc_bulk(BATCH_SIZE)
 }
 

--- a/bench/packets.rs
+++ b/bench/packets.rs
@@ -16,6 +16,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::ip::v6::{Ipv6, SegmentRouting};
 use capsule::packets::{Ethernet, Packet, Udp4};
@@ -24,7 +25,6 @@ use capsule::testils::proptest::*;
 use capsule::testils::{PacketExt, Rvg};
 use capsule::{fieldmap, Mbuf};
 use criterion::{criterion_group, criterion_main, Criterion};
-use failure::Fallible;
 use proptest::prelude::*;
 use std::net::Ipv6Addr;
 
@@ -228,7 +228,7 @@ fn multi_remove(c: &mut Criterion) {
     });
 }
 
-fn set_srh_segments(mut args: (SegmentRouting<Ipv6>, Vec<Ipv6Addr>)) -> Fallible<()> {
+fn set_srh_segments(mut args: (SegmentRouting<Ipv6>, Vec<Ipv6Addr>)) -> Result<()> {
     args.0.set_segments(&args.1)
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule-ffi = { version = "0.1.4", path = "../ffi" }
 capsule-macros = { version = "0.1.4", path = "../macros" }
 clap = "2.33"
@@ -33,6 +34,7 @@ once_cell = "1.2"
 proptest = { version = "0.10", optional = true }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 tokio = "=0.2.0-alpha.6"
 tokio-executor = { version = "=0.2.0-alpha.6", features = ["current-thread", "threadpool"] }
 tokio-net = { version = "=0.2.0-alpha.6", features = ["signal"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,6 @@ capsule-ffi = { version = "0.1.4", path = "../ffi" }
 capsule-macros = { version = "0.1.4", path = "../macros" }
 clap = "2.33"
 criterion = { version = "0.3", optional = true }
-failure = "0.1"
 futures-preview = "=0.3.0-alpha.19"
 libc = "0.2"
 metrics-core = { version = "0.5", optional = true }

--- a/core/src/batch/filter_map.rs
+++ b/core/src/batch/filter_map.rs
@@ -19,7 +19,7 @@
 use super::{Batch, Disposition};
 use crate::packets::Packet;
 use crate::Mbuf;
-use failure::Fallible;
+use anyhow::Result;
 
 /// The result of a [`filter_map`].
 ///
@@ -41,7 +41,7 @@ pub enum Either<T> {
 #[allow(missing_debug_implementations)]
 pub struct FilterMap<B: Batch, T: Packet, F>
 where
-    F: FnMut(B::Item) -> Fallible<Either<T>>,
+    F: FnMut(B::Item) -> Result<Either<T>>,
 {
     batch: B,
     f: F,
@@ -49,7 +49,7 @@ where
 
 impl<B: Batch, T: Packet, F> FilterMap<B, T, F>
 where
-    F: FnMut(B::Item) -> Fallible<Either<T>>,
+    F: FnMut(B::Item) -> Result<Either<T>>,
 {
     /// Creates a new `FilterMap` batch.
     #[inline]
@@ -60,7 +60,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for FilterMap<B, T, F>
 where
-    F: FnMut(B::Item) -> Fallible<Either<T>>,
+    F: FnMut(B::Item) -> Result<Either<T>>,
 {
     type Item = T;
 

--- a/core/src/batch/for_each.rs
+++ b/core/src/batch/for_each.rs
@@ -17,13 +17,13 @@
 */
 
 use super::{Batch, Disposition};
-use failure::Fallible;
+use anyhow::Result;
 
 /// A batch that calls a closure on packets in the underlying batch.
 #[allow(missing_debug_implementations)]
 pub struct ForEach<B: Batch, F>
 where
-    F: FnMut(&B::Item) -> Fallible<()>,
+    F: FnMut(&B::Item) -> Result<()>,
 {
     batch: B,
     f: F,
@@ -31,7 +31,7 @@ where
 
 impl<B: Batch, F> ForEach<B, F>
 where
-    F: FnMut(&B::Item) -> Fallible<()>,
+    F: FnMut(&B::Item) -> Result<()>,
 {
     /// Creates a new `ForEach` batch.
     #[inline]
@@ -42,7 +42,7 @@ where
 
 impl<B: Batch, F> Batch for ForEach<B, F>
 where
-    F: FnMut(&B::Item) -> Fallible<()>,
+    F: FnMut(&B::Item) -> Result<()>,
 {
     type Item = B::Item;
 

--- a/core/src/batch/map.rs
+++ b/core/src/batch/map.rs
@@ -18,7 +18,7 @@
 
 use super::{Batch, Disposition};
 use crate::packets::Packet;
-use failure::Fallible;
+use anyhow::Result;
 
 /// A batch that maps the packets of the underlying batch.
 ///
@@ -27,7 +27,7 @@ use failure::Fallible;
 #[allow(missing_debug_implementations)]
 pub struct Map<B: Batch, T: Packet, F>
 where
-    F: FnMut(B::Item) -> Fallible<T>,
+    F: FnMut(B::Item) -> Result<T>,
 {
     batch: B,
     f: F,
@@ -35,7 +35,7 @@ where
 
 impl<B: Batch, T: Packet, F> Map<B, T, F>
 where
-    F: FnMut(B::Item) -> Fallible<T>,
+    F: FnMut(B::Item) -> Result<T>,
 {
     /// Creates a new `Map` batch.
     #[inline]
@@ -46,7 +46,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for Map<B, T, F>
 where
-    F: FnMut(B::Item) -> Fallible<T>,
+    F: FnMut(B::Item) -> Result<T>,
 {
     type Item = T;
 

--- a/core/src/batch/mod.rs
+++ b/core/src/batch/mod.rs
@@ -44,7 +44,7 @@ pub use self::send::*;
 
 use crate::packets::Packet;
 use crate::Mbuf;
-use failure::{Error, Fallible};
+use anyhow::{Error, Result};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -198,7 +198,7 @@ pub trait Batch {
     #[inline]
     fn filter_map<T: Packet, F>(self, f: F) -> FilterMap<Self, T, F>
     where
-        F: FnMut(Self::Item) -> Fallible<Either<T>>,
+        F: FnMut(Self::Item) -> Result<Either<T>>,
         Self: Sized,
     {
         FilterMap::new(self, f)
@@ -216,7 +216,7 @@ pub trait Batch {
     #[inline]
     fn map<T: Packet, F>(self, f: F) -> Map<Self, T, F>
     where
-        F: FnMut(Self::Item) -> Fallible<T>,
+        F: FnMut(Self::Item) -> Result<T>,
         Self: Sized,
     {
         Map::new(self, f)
@@ -238,7 +238,7 @@ pub trait Batch {
     #[inline]
     fn for_each<F>(self, f: F) -> ForEach<Self, F>
     where
-        F: FnMut(&Self::Item) -> Fallible<()>,
+        F: FnMut(&Self::Item) -> Result<()>,
         Self: Sized,
     {
         ForEach::new(self, f)
@@ -343,7 +343,7 @@ pub trait Batch {
     /// });
     fn replace<T: Packet, F>(self, f: F) -> Replace<Self, T, F>
     where
-        F: FnMut(&Self::Item) -> Fallible<T>,
+        F: FnMut(&Self::Item) -> Result<T>,
         Self: Sized,
     {
         Replace::new(self, f)

--- a/core/src/batch/replace.rs
+++ b/core/src/batch/replace.rs
@@ -18,7 +18,7 @@
 
 use super::{Batch, Disposition};
 use crate::packets::Packet;
-use failure::Fallible;
+use anyhow::Result;
 
 /// A batch that replaces each packet of the batch with another packet.
 ///
@@ -28,7 +28,7 @@ use failure::Fallible;
 #[allow(missing_debug_implementations)]
 pub struct Replace<B: Batch, T: Packet, F>
 where
-    F: FnMut(&B::Item) -> Fallible<T>,
+    F: FnMut(&B::Item) -> Result<T>,
 {
     batch: B,
     f: F,
@@ -37,7 +37,7 @@ where
 
 impl<B: Batch, T: Packet, F> Replace<B, T, F>
 where
-    F: FnMut(&B::Item) -> Fallible<T>,
+    F: FnMut(&B::Item) -> Result<T>,
 {
     /// Creates a new `Replace` batch.
     #[inline]
@@ -52,7 +52,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for Replace<B, T, F>
 where
-    F: FnMut(&B::Item) -> Fallible<T>,
+    F: FnMut(&B::Item) -> Result<T>,
 {
     type Item = T;
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -47,8 +47,8 @@
 
 use crate::dpdk::CoreId;
 use crate::net::{Ipv4Cidr, Ipv6Cidr, MacAddr};
+use anyhow::Result;
 use clap::{clap_app, crate_version};
-use failure::Fallible;
 use regex::Regex;
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
@@ -412,7 +412,7 @@ impl fmt::Debug for PortConfig {
 /// ```
 /// home$ ./myapp -f config.toml
 /// ```
-pub fn load_config() -> Fallible<RuntimeConfig> {
+pub fn load_config() -> Result<RuntimeConfig> {
     let matches = clap_app!(capsule =>
         (version: crate_version!())
         (@arg file: -f --file +required +takes_value "configuration file")

--- a/core/src/dpdk/kni.rs
+++ b/core/src/dpdk/kni.rs
@@ -233,7 +233,7 @@ unsafe impl Send for KniRx {}
 unsafe impl Send for KniTx {}
 
 /// KNI errors.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum KniError {
     #[error("KNI is not enabled for the port.")]
     Disabled,

--- a/core/src/dpdk/kni.rs
+++ b/core/src/dpdk/kni.rs
@@ -24,12 +24,13 @@ use crate::ffi::{self, AsStr, ToResult};
 use crate::metrics::{labels, Counter, SINK};
 use crate::net::MacAddr;
 use crate::{debug, error, warn};
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use futures::{future, Future, StreamExt};
 use std::cmp;
 use std::mem;
 use std::os::raw;
 use std::ptr::{self, NonNull};
+use thiserror::Error;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 /// Creates a new KNI counter.
@@ -232,12 +233,12 @@ unsafe impl Send for KniRx {}
 unsafe impl Send for KniTx {}
 
 /// KNI errors.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub(crate) enum KniError {
-    #[fail(display = "KNI is not enabled for the port.")]
+    #[error("KNI is not enabled for the port.")]
     Disabled,
 
-    #[fail(display = "Another core owns the handle.")]
+    #[error("Another core owns the handle.")]
     NotAcquired,
 }
 
@@ -277,12 +278,12 @@ impl Kni {
     }
 
     /// Takes ownership of the RX handle.
-    pub(crate) fn take_rx(&mut self) -> Fallible<KniRx> {
+    pub(crate) fn take_rx(&mut self) -> Result<KniRx> {
         self.rx.take().ok_or_else(|| KniError::NotAcquired.into())
     }
 
     /// Takes ownership of the TX handle.
-    pub(crate) fn take_tx(&mut self) -> Fallible<KniTx> {
+    pub(crate) fn take_tx(&mut self) -> Result<KniTx> {
         self.tx.take().ok_or_else(|| KniError::NotAcquired.into())
     }
 
@@ -378,7 +379,7 @@ impl<'a> KniBuilder<'a> {
         self
     }
 
-    pub(crate) fn finish(&mut self) -> Fallible<Kni> {
+    pub(crate) fn finish(&mut self) -> Result<Kni> {
         self.conf.mbuf_size = ffi::RTE_MBUF_DEFAULT_BUF_SIZE;
         self.ops.change_mtu = Some(change_mtu);
         self.ops.config_network_if = Some(config_network_if);
@@ -394,7 +395,7 @@ impl<'a> KniBuilder<'a> {
 }
 
 /// Initializes and preallocates the KNI subsystem.
-pub(crate) fn kni_init(max: usize) -> Fallible<()> {
+pub(crate) fn kni_init(max: usize) -> Result<()> {
     unsafe {
         ffi::rte_kni_init(max as raw::c_uint)
             .to_result(DpdkError::from_errno)

--- a/core/src/dpdk/mbuf.rs
+++ b/core/src/dpdk/mbuf.rs
@@ -82,7 +82,7 @@ impl SizeOf for ::std::net::Ipv6Addr {
 }
 
 /// Error indicating buffer access failures.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum BufferError {
     /// The offset exceeds the buffer length.
     #[error("Offset {0} exceeds the buffer length {1}.")]

--- a/core/src/dpdk/mbuf.rs
+++ b/core/src/dpdk/mbuf.rs
@@ -21,12 +21,13 @@ use crate::dpdk::{DpdkError, MempoolError};
 use crate::ffi::{self, ToResult};
 use crate::packets::{Internal, Packet};
 use crate::{ensure, trace};
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use std::fmt;
 use std::mem;
 use std::os::raw;
 use std::ptr::{self, NonNull};
 use std::slice;
+use thiserror::Error;
 
 /// A trait for returning the size of a type in bytes.
 ///
@@ -81,21 +82,18 @@ impl SizeOf for ::std::net::Ipv6Addr {
 }
 
 /// Error indicating buffer access failures.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub(crate) enum BufferError {
     /// The offset exceeds the buffer length.
-    #[fail(display = "Offset {} exceeds the buffer length {}.", _0, _1)]
+    #[error("Offset {0} exceeds the buffer length {1}.")]
     BadOffset(usize, usize),
 
     /// The buffer is not resized.
-    #[fail(display = "Buffer is not resized.")]
+    #[error("Buffer is not resized.")]
     NotResized,
 
     /// The struct size exceeds the remaining buffer length.
-    #[fail(
-        display = "Struct size {} exceeds the remaining buffer length {}.",
-        _0, _1
-    )]
+    #[error("Struct size {0} exceeds the remaining buffer length {1}.")]
     OutOfBuffer(usize, usize),
 }
 
@@ -143,8 +141,12 @@ impl Mbuf {
     /// The Mbuf is allocated from the `Mempool` assigned to the current
     /// executing thread by the `Runtime`. The call will fail if invoked
     /// from a thread not managed by the `Runtime`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MempoolError::Exhausted` if the allocation of mbuf fails.
     #[inline]
-    pub fn new() -> Fallible<Self> {
+    pub fn new() -> Result<Self> {
         let mempool = MEMPOOL.with(|tls| tls.get());
         let raw =
             unsafe { ffi::_rte_pktmbuf_alloc(mempool).to_result(|_| MempoolError::Exhausted)? };
@@ -155,8 +157,14 @@ impl Mbuf {
     }
 
     /// Creates a new message buffer from a byte array.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MempoolError::Exhausted` if the allocation of mbuf fails.
+    /// Returns `BufferError::NotResized` if the byte array is larger than
+    /// the maximum mbuf size.
     #[inline]
-    pub fn from_bytes(data: &[u8]) -> Fallible<Self> {
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
         let mut mbuf = Mbuf::new()?;
         mbuf.extend(0, data.len())?;
         mbuf.write_data_slice(0, data)?;
@@ -207,8 +215,14 @@ impl Mbuf {
     ///
     /// If the offset is not at the end of the data. The data after the
     /// offset is shifted down to make room.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::NotResized` if the offset is out of bound,
+    /// or the length to extend is either 0 or exceeds the available free
+    /// buffer capacity.
     #[inline]
-    pub fn extend(&mut self, offset: usize, len: usize) -> Fallible<()> {
+    pub fn extend(&mut self, offset: usize, len: usize) -> Result<()> {
         ensure!(len > 0, BufferError::NotResized);
         ensure!(offset <= self.data_len(), BufferError::NotResized);
         ensure!(len < self.tailroom(), BufferError::NotResized);
@@ -233,8 +247,13 @@ impl Mbuf {
     /// Shrinks the data buffer at offset by `len` bytes.
     ///
     /// The data at offset is shifted up.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::NotResized` if the length to shrink is either
+    /// 0 or exceeds the used buffer size starting at offset.
     #[inline]
-    pub fn shrink(&mut self, offset: usize, len: usize) -> Fallible<()> {
+    pub fn shrink(&mut self, offset: usize, len: usize) -> Result<()> {
         ensure!(len > 0, BufferError::NotResized);
         ensure!(offset + len <= self.data_len(), BufferError::NotResized);
 
@@ -256,8 +275,10 @@ impl Mbuf {
     }
 
     /// Resizes the data buffer.
+    ///
+    /// Delegates to either `extend` or `shrink`.
     #[inline]
-    pub fn resize(&mut self, offset: usize, len: isize) -> Fallible<()> {
+    pub fn resize(&mut self, offset: usize, len: isize) -> Result<()> {
         if len < 0 {
             self.shrink(offset, -len as usize)
         } else {
@@ -266,8 +287,13 @@ impl Mbuf {
     }
 
     /// Truncates the data buffer to len.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::NotResized` if the target length exceeds the
+    /// actual used buffer size.
     #[inline]
-    pub fn truncate(&mut self, to_len: usize) -> Fallible<()> {
+    pub fn truncate(&mut self, to_len: usize) -> Result<()> {
         ensure!(to_len < self.data_len(), BufferError::NotResized);
 
         self.raw_mut().data_len = to_len as u16;
@@ -277,8 +303,14 @@ impl Mbuf {
     }
 
     /// Reads the data at offset as `T` and returns it as a raw pointer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::BadOffset` if the offset is out of bound.
+    /// Returns `BufferError::OutOfBuffer` if the size of `T` exceeds the
+    /// size of the data stored at offset.
     #[inline]
-    pub fn read_data<T: SizeOf>(&self, offset: usize) -> Fallible<NonNull<T>> {
+    pub fn read_data<T: SizeOf>(&self, offset: usize) -> Result<NonNull<T>> {
         ensure!(
             offset < self.data_len(),
             BufferError::BadOffset(offset, self.data_len())
@@ -300,8 +332,13 @@ impl Mbuf {
     /// Before writing to the data buffer, should call `Mbuf::extend` first
     /// to make sure enough space is allocated for the write and data is not
     /// being overridden.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::OutOfBuffer` if the size of `T` exceeds the
+    /// available buffer capacity starting at offset.
     #[inline]
-    pub fn write_data<T: SizeOf>(&mut self, offset: usize, item: &T) -> Fallible<NonNull<T>> {
+    pub fn write_data<T: SizeOf>(&mut self, offset: usize, item: &T) -> Result<NonNull<T>> {
         ensure!(
             offset + T::size_of() <= self.data_len(),
             BufferError::OutOfBuffer(T::size_of(), self.data_len() - offset)
@@ -318,12 +355,14 @@ impl Mbuf {
 
     /// Reads the data at offset as a slice of `T` and returns the slice as
     /// a raw pointer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::BadOffset` if the offset is out of bound.
+    /// Returns `BufferError::OutOfBuffer` if the size of `T` slice exceeds
+    /// the size of the data stored at offset.
     #[inline]
-    pub fn read_data_slice<T: SizeOf>(
-        &self,
-        offset: usize,
-        count: usize,
-    ) -> Fallible<NonNull<[T]>> {
+    pub fn read_data_slice<T: SizeOf>(&self, offset: usize, count: usize) -> Result<NonNull<[T]>> {
         ensure!(
             offset < self.data_len(),
             BufferError::BadOffset(offset, self.data_len())
@@ -346,12 +385,17 @@ impl Mbuf {
     /// Before writing to the data buffer, should call `Mbuf::extend` first
     /// to make sure enough space is allocated for the write and data is not
     /// being overridden.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufferError::OutOfBuffer` if the size of `T` slice exceeds
+    /// the available buffer capacity starting at offset.
     #[inline]
     pub fn write_data_slice<T: SizeOf>(
         &mut self,
         offset: usize,
         slice: &[T],
-    ) -> Fallible<NonNull<[T]>> {
+    ) -> Result<NonNull<[T]>> {
         let count = slice.len();
 
         ensure!(
@@ -380,7 +424,11 @@ impl Mbuf {
     }
 
     /// Allocates a Vec of `Mbuf`s of `len` size.
-    pub fn alloc_bulk(len: usize) -> Fallible<Vec<Mbuf>> {
+    ///
+    /// # Errors
+    ///
+    /// Returns `DpdkError` if the allocation of mbuf fails.
+    pub fn alloc_bulk(len: usize) -> Result<Vec<Mbuf>> {
         let mut ptrs = Vec::with_capacity(len);
         let mempool = MEMPOOL.with(|tls| tls.get());
 
@@ -479,12 +527,12 @@ impl Packet for Mbuf {
     }
 
     #[inline]
-    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         Ok(envelope)
     }
 
     #[inline]
-    fn try_push(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_push(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         Ok(envelope)
     }
 
@@ -494,7 +542,7 @@ impl Packet for Mbuf {
     }
 
     #[inline]
-    fn remove(self) -> Fallible<Self::Envelope> {
+    fn remove(self) -> Result<Self::Envelope> {
         Ok(self)
     }
 

--- a/core/src/dpdk/mempool.rs
+++ b/core/src/dpdk/mempool.rs
@@ -128,7 +128,7 @@ thread_local! {
 }
 
 /// Error indicating the `Mempool` is not found or is exhaused.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum MempoolError {
     #[error("Cannot allocate a new mbuf from mempool")]
     Exhausted,

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -36,17 +36,18 @@ pub(crate) use self::stats::*;
 use crate::debug;
 use crate::ffi::{self, AsStr, ToCString, ToResult};
 use crate::net::MacAddr;
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use std::cell::Cell;
 use std::fmt;
 use std::mem;
 use std::os::raw;
+use thiserror::Error;
 
 /// An error generated in `libdpdk`.
 ///
 /// When an FFI call fails, the `errno` is translated into `DpdkError`.
-#[derive(Debug, Fail)]
-#[fail(display = "{}", _0)]
+#[derive(Error, Debug)]
+#[error("{0}")]
 pub(crate) struct DpdkError(String);
 
 impl DpdkError {
@@ -151,7 +152,7 @@ impl CoreId {
     /// Sets the current thread's affinity to this core.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
-    pub(crate) fn set_thread_affinity(&self) -> Fallible<()> {
+    pub(crate) fn set_thread_affinity(&self) -> Result<()> {
         unsafe {
             // the two types that represent `cpu_set` have identical layout,
             // hence it is safe to transmute between them.
@@ -177,7 +178,7 @@ thread_local! {
 }
 
 /// Initializes the Environment Abstraction Layer (EAL).
-pub(crate) fn eal_init(args: Vec<String>) -> Fallible<()> {
+pub(crate) fn eal_init(args: Vec<String>) -> Result<()> {
     debug!(arguments=?args);
 
     let len = args.len() as raw::c_int;
@@ -194,7 +195,7 @@ pub(crate) fn eal_init(args: Vec<String>) -> Fallible<()> {
 }
 
 /// Cleans up the Environment Abstraction Layer (EAL).
-pub(crate) fn eal_cleanup() -> Fallible<()> {
+pub(crate) fn eal_cleanup() -> Result<()> {
     unsafe {
         ffi::rte_eal_cleanup()
             .to_result(DpdkError::from_errno)

--- a/core/src/dpdk/mod.rs
+++ b/core/src/dpdk/mod.rs
@@ -46,7 +46,7 @@ use thiserror::Error;
 /// An error generated in `libdpdk`.
 ///
 /// When an FFI call fails, the `errno` is translated into `DpdkError`.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 #[error("{0}")]
 pub(crate) struct DpdkError(String);
 

--- a/core/src/dpdk/port.rs
+++ b/core/src/dpdk/port.rs
@@ -25,11 +25,12 @@ use crate::net::MacAddr;
 #[cfg(feature = "pcap-dump")]
 use crate::pcap;
 use crate::{debug, ensure, info, warn};
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use std::collections::HashMap;
 use std::fmt;
 use std::os::raw;
 use std::ptr;
+use thiserror::Error;
 
 const DEFAULT_RSS_HF: u64 =
     (ffi::ETH_RSS_IP | ffi::ETH_RSS_TCP | ffi::ETH_RSS_UDP | ffi::ETH_RSS_SCTP) as u64;
@@ -257,23 +258,23 @@ impl PortQueue {
 }
 
 /// Error indicating failed to initialize the port.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub(crate) enum PortError {
     /// Port is not found.
-    #[fail(display = "Port {} is not found.", _0)]
+    #[error("Port {0} is not found.")]
     NotFound(String),
 
-    #[fail(display = "Port is not bound to any cores.")]
+    #[error("Port is not bound to any cores.")]
     CoreNotBound,
 
     /// The maximum number of RX queues is less than the number of cores
     /// assigned to the port.
-    #[fail(display = "Insufficient number of RX queues '{}'.", _0)]
+    #[error("Insufficient number of RX queues '{0}'.")]
     InsufficientRxQueues(usize),
 
     /// The maximum number of TX queues is less than the number of cores
     /// assigned to the port.
-    #[fail(display = "Insufficient number of TX queues '{}'.", _0)]
+    #[error("Insufficient number of TX queues '{0}'.")]
     InsufficientTxQueues(usize),
 }
 
@@ -323,7 +324,7 @@ impl Port {
     /// # Errors
     ///
     /// If the port fails to start, `DpdkError` is returned.
-    pub(crate) fn start(&mut self) -> Fallible<()> {
+    pub(crate) fn start(&mut self) -> Result<()> {
         unsafe {
             ffi::rte_eth_dev_start(self.id.0).to_result(DpdkError::from_errno)?;
         }
@@ -396,7 +397,7 @@ impl<'a> PortBuilder<'a> {
     /// # Errors
     ///
     /// If the device is not found, `DpdkError` is returned.
-    pub(crate) fn new(name: String, device: String) -> Fallible<Self> {
+    pub(crate) fn new(name: String, device: String) -> Result<Self> {
         let mut port_id = 0u16;
         unsafe {
             ffi::rte_eth_dev_get_port_by_name(device.clone().to_cstring().as_ptr(), &mut port_id)
@@ -432,7 +433,7 @@ impl<'a> PortBuilder<'a> {
     ///
     /// If either the maximum number of RX or TX queues is less than the
     /// number of cores assigned, `PortError` is returned.
-    pub(crate) fn cores(&mut self, cores: &[CoreId]) -> Fallible<&mut Self> {
+    pub(crate) fn cores(&mut self, cores: &[CoreId]) -> Result<&mut Self> {
         ensure!(!cores.is_empty(), PortError::CoreNotBound);
 
         let mut cores = cores.to_vec();
@@ -462,7 +463,7 @@ impl<'a> PortBuilder<'a> {
     /// # Errors
     ///
     /// If the adjustment failed, `DpdkError` is returned.
-    pub(crate) fn rx_tx_queue_capacity(&mut self, rxd: usize, txd: usize) -> Fallible<&mut Self> {
+    pub(crate) fn rx_tx_queue_capacity(&mut self, rxd: usize, txd: usize) -> Result<&mut Self> {
         let mut rxd2 = rxd as u16;
         let mut txd2 = txd as u16;
 
@@ -502,7 +503,7 @@ impl<'a> PortBuilder<'a> {
         promiscuous: bool,
         multicast: bool,
         with_kni: bool,
-    ) -> Fallible<Port> {
+    ) -> anyhow::Result<Port> {
         let len = self.cores.len() as u16;
         let mut conf = ffi::rte_eth_conf::default();
 

--- a/core/src/dpdk/port.rs
+++ b/core/src/dpdk/port.rs
@@ -258,7 +258,7 @@ impl PortQueue {
 }
 
 /// Error indicating failed to initialize the port.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum PortError {
     /// Port is not found.
     #[error("Port {0} is not found.")]

--- a/core/src/dpdk/stats.rs
+++ b/core/src/dpdk/stats.rs
@@ -20,7 +20,7 @@ use super::{Mempool, Port, PortId};
 use crate::dpdk::DpdkError;
 use crate::ffi::{self, AsStr, ToResult};
 use crate::metrics::{labels, Key, Measurement};
-use failure::Fallible;
+use anyhow::Result;
 use std::ptr::NonNull;
 
 /// Port stats collector.
@@ -58,7 +58,7 @@ impl PortStats {
     }
 
     /// Collects the port stats tracked by DPDK.
-    pub(crate) fn collect(&self) -> Fallible<Vec<(Key, Measurement)>> {
+    pub(crate) fn collect(&self) -> Result<Vec<(Key, Measurement)>> {
         let mut stats = ffi::rte_eth_stats::default();
         unsafe {
             ffi::rte_eth_stats_get(self.id.raw(), &mut stats).to_result(DpdkError::from_errno)?;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -78,7 +78,7 @@ pub(crate) use metrics_runtime::Measurement;
 
 use crate::dpdk::{Mempool, MempoolStats, Port};
 use crate::warn;
-use failure::{format_err, Fallible};
+use anyhow::{anyhow, Result};
 use metrics_runtime::{Receiver, Sink};
 use once_cell::sync::{Lazy, OnceCell};
 
@@ -89,12 +89,12 @@ static RECEIVER: OnceCell<Receiver> = OnceCell::new();
 /// potentially fail, the `Lazy` convenience type is not safe.
 ///
 /// Also very important that `init` is not called twice.
-pub(crate) fn init() -> Fallible<()> {
+pub(crate) fn init() -> Result<()> {
     let receiver = Receiver::builder().build()?;
 
     RECEIVER
         .set(receiver)
-        .map_err(|_| format_err!("already initialized."))?;
+        .map_err(|_| anyhow!("already initialized."))?;
     Ok(())
 }
 

--- a/core/src/net/cidr/mod.rs
+++ b/core/src/net/cidr/mod.rs
@@ -24,17 +24,17 @@ pub use self::v4::Ipv4Cidr;
 #[allow(unreachable_pub)]
 pub use self::v6::Ipv6Cidr;
 
-use failure::Fail;
+use thiserror::Error;
 
 /// Error indicating that a CIDR range cannot be parsed or is handled with an invalid prefix length.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum CidrError {
     /// Error returned when parsing a malformed CIDR range.
-    #[fail(display = "Failed to parse CIDR: {}", _0)]
+    #[error("Failed to parse CIDR: {0}")]
     Malformed(String),
 
     /// Error returned when converting from v4/v6 address mask to a prefix length.
-    #[fail(display = "Invalid prefix length")]
+    #[error("Invalid prefix length")]
     InvalidPrefixLength,
 }
 

--- a/core/src/net/cidr/mod.rs
+++ b/core/src/net/cidr/mod.rs
@@ -27,7 +27,7 @@ pub use self::v6::Ipv6Cidr;
 use thiserror::Error;
 
 /// Error indicating that a CIDR range cannot be parsed or is handled with an invalid prefix length.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum CidrError {
     /// Error returned when parsing a malformed CIDR range.
     #[error("Failed to parse CIDR: {0}")]

--- a/core/src/net/mac.rs
+++ b/core/src/net/mac.rs
@@ -16,10 +16,10 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-use failure::Fail;
 use std::convert::From;
 use std::fmt;
 use std::str::FromStr;
+use thiserror::Error;
 
 /// Ethernet MAC address.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
@@ -60,8 +60,8 @@ impl From<[u8; 6]> for MacAddr {
 }
 
 /// Error returned when parsing a malformed MAC address.
-#[derive(Debug, Fail)]
-#[fail(display = "Failed to parse '{}' as MAC address.", _0)]
+#[derive(Error, Debug)]
+#[error("Failed to parse '{0}' as MAC address.")]
 pub struct MacParseError(String);
 
 impl FromStr for MacAddr {

--- a/core/src/net/mac.rs
+++ b/core/src/net/mac.rs
@@ -60,7 +60,7 @@ impl From<[u8; 6]> for MacAddr {
 }
 
 /// Error returned when parsing a malformed MAC address.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 #[error("Failed to parse '{0}' as MAC address.")]
 pub struct MacParseError(String);
 

--- a/core/src/packets/checksum.rs
+++ b/core/src/packets/checksum.rs
@@ -19,8 +19,8 @@
 //! Common checksum capabilities and computations for all packet types,
 //! including calculation involving *pseudo headers*.
 
-use crate::packets::ip::{IpPacketError, ProtocolNumber};
-use anyhow::Result;
+use crate::packets::ip::ProtocolNumber;
+use anyhow::{anyhow, Result};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::slice;
 
@@ -195,6 +195,10 @@ pub fn compute_inc(old_checksum: u16, old_value: &[u16], new_value: &[u16]) -> u
 }
 
 /// Incrementally computes the new checksum for an IP address change.
+///
+/// # Errors
+///
+/// Returns an error if the addresses are not of the same address family.
 pub fn compute_with_ipaddr(
     old_checksum: u16,
     old_value: &IpAddr,
@@ -211,7 +215,7 @@ pub fn compute_with_ipaddr(
         (IpAddr::V6(old), IpAddr::V6(new)) => {
             Ok(compute_inc(old_checksum, &old.segments(), &new.segments()))
         }
-        _ => Err(IpPacketError::IpAddrMismatch.into()),
+        _ => Err(anyhow!("cannot mix IPv4 and IPv6 addresses.")),
     }
 }
 

--- a/core/src/packets/checksum.rs
+++ b/core/src/packets/checksum.rs
@@ -20,7 +20,7 @@
 //! including calculation involving *pseudo headers*.
 
 use crate::packets::ip::{IpPacketError, ProtocolNumber};
-use failure::Fallible;
+use anyhow::Result;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::slice;
 
@@ -199,7 +199,7 @@ pub fn compute_with_ipaddr(
     old_checksum: u16,
     old_value: &IpAddr,
     new_value: &IpAddr,
-) -> Fallible<u16> {
+) -> Result<u16> {
     match (old_value, new_value) {
         (IpAddr::V4(old), IpAddr::V4(new)) => {
             let old: u32 = (*old).into();

--- a/core/src/packets/ethernet.rs
+++ b/core/src/packets/ethernet.rs
@@ -21,7 +21,7 @@ use crate::net::MacAddr;
 use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::{ensure, Mbuf, SizeOf};
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -269,8 +269,14 @@ impl Packet for Ethernet {
         }
     }
 
+    /// Parses the mbuf's payload as `Ethernet`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `Ethernet` header is larger than the data
+    /// payload.
     #[inline]
-    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         let mbuf = envelope.mbuf();
         let offset = envelope.payload_offset();
         let header = mbuf.read_data(offset)?;
@@ -293,8 +299,13 @@ impl Packet for Ethernet {
         Ok(packet)
     }
 
+    /// Prepends a new packet to the beginning of the envelope's payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         let offset = envelope.payload_offset();
         let mbuf = envelope.mbuf_mut();
 

--- a/core/src/packets/icmp/v4/echo_request.rs
+++ b/core/src/packets/icmp/v4/echo_request.rs
@@ -20,7 +20,7 @@ use crate::packets::icmp::v4::{Icmpv4, Icmpv4Message, Icmpv4Packet, Icmpv4Type, 
 use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -115,8 +115,12 @@ impl EchoRequest {
     }
 
     /// Sets the data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.icmp_mut().mbuf_mut().resize(offset, len)?;
@@ -169,8 +173,14 @@ impl Icmpv4Message for EchoRequest {
         }
     }
 
+    /// Parses the ICMPv4 packet's payload as echo request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the echo request message body.
     #[inline]
-    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -178,8 +188,14 @@ impl Icmpv4Message for EchoRequest {
         Ok(EchoRequest { icmp, body })
     }
 
+    /// Prepends a new echo request message to the beginning of the ICMPv4's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -37,7 +37,6 @@ use crate::{ensure, SizeOf};
 use anyhow::{anyhow, Result};
 use std::fmt;
 use std::ptr::NonNull;
-use thiserror::Error;
 
 /// Internet Control Message Protocol v4 packet based on [IETF RFC 792].
 ///
@@ -159,11 +158,6 @@ impl fmt::Debug for Icmpv4 {
     }
 }
 
-/// Error when trying to push a generic ICMPv4 header without a message body.
-#[derive(Debug, Error)]
-#[error("Cannot push a generic ICMPv4 header without a message body.")]
-pub struct NoIcmpv4MessageBody;
-
 impl Packet for Icmpv4 {
     /// The preceding type for ICMPv4 packet must be IPv4.
     type Envelope = Ipv4;
@@ -226,15 +220,15 @@ impl Packet for Icmpv4 {
     }
 
     /// Cannot push a generic ICMPv4 header without a message body. This
-    /// will always return [`NoIcmpv4MessageBody`]. Instead, push a specific
-    /// message type like [`EchoRequest`], which includes the header and
-    /// the message body.
+    /// will always error. Instead, push a specific message type like
+    /// [`EchoRequest`], which includes the header and the message body.
     ///
-    /// [`NoIcmpv4MessageBody`]: NoIcmpv4MessageBody
     /// [`EchoRequest`]: EchoRequest
     #[inline]
     fn try_push(_envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
-        Err(NoIcmpv4MessageBody.into())
+        Err(anyhow!(
+            "cannot push a generic ICMPv4 header without a message body."
+        ))
     }
 
     #[inline]

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -32,11 +32,12 @@ pub use capsule_macros::Icmpv4Packet;
 use crate::packets::ip::v4::Ipv4;
 use crate::packets::ip::ProtocolNumbers;
 use crate::packets::types::u16be;
-use crate::packets::{checksum, Internal, Packet, ParseError};
+use crate::packets::{checksum, Internal, Packet};
 use crate::{ensure, SizeOf};
-use failure::{Fail, Fallible};
+use anyhow::{anyhow, Result};
 use std::fmt;
 use std::ptr::NonNull;
+use thiserror::Error;
 
 /// Internet Control Message Protocol v4 packet based on [IETF RFC 792].
 ///
@@ -130,13 +131,15 @@ impl Icmpv4 {
 
     /// Casts the ICMPv4 packet to a message of type `T`.
     ///
+    /// # Errors
+    ///
     /// Returns an error if the message type in the packet header does not
     /// match the assigned message type for `T`.
     #[inline]
-    pub fn downcast<T: Icmpv4Message>(self) -> Fallible<T> {
+    pub fn downcast<T: Icmpv4Message>(self) -> Result<T> {
         ensure!(
             self.msg_type() == T::msg_type(),
-            ParseError::new(&format!("The ICMPv4 packet is not {}.", T::msg_type()))
+            anyhow!("the ICMPv4 packet is not {}.", T::msg_type())
         );
 
         T::try_parse(self, Internal(()))
@@ -157,8 +160,8 @@ impl fmt::Debug for Icmpv4 {
 }
 
 /// Error when trying to push a generic ICMPv4 header without a message body.
-#[derive(Debug, Fail)]
-#[fail(display = "Cannot push a generic ICMPv4 header without a message body.")]
+#[derive(Error, Debug)]
+#[error("Cannot push a generic ICMPv4 header without a message body.")]
 pub struct NoIcmpv4MessageBody;
 
 impl Packet for Icmpv4 {
@@ -196,16 +199,19 @@ impl Packet for Icmpv4 {
 
     /// Parses the envelope's payload as an ICMPv4 packet.
     ///
-    /// [`Ipv4::protocol`] must be set to [`ProtocolNumbers::Icmpv4`].
-    /// Otherwise, a parsing error is returned.
+    /// # Errors
+    ///
+    /// Returns an error if [`Ipv4::protocol`] is not set to [`ProtocolNumbers::Icmpv4`].
+    /// Returns an error if the payload does not have sufficient data for the
+    /// ICMPv4 header.
     ///
     /// [`Ipv4::protocol`]: crate::packets::ip::v4::Ipv4::protocol
     /// [`ProtocolNumbers::Icmpv4`]: crate::packets::ip::ProtocolNumbers::Icmpv4
     #[inline]
-    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         ensure!(
             envelope.protocol() == ProtocolNumbers::Icmpv4,
-            ParseError::new("not an ICMPv4 packet.")
+            anyhow!("not an ICMPv4 packet.")
         );
 
         let mbuf = envelope.mbuf();
@@ -227,7 +233,7 @@ impl Packet for Icmpv4 {
     /// [`NoIcmpv4MessageBody`]: NoIcmpv4MessageBody
     /// [`EchoRequest`]: EchoRequest
     #[inline]
-    fn try_push(_envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_push(_envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         Err(NoIcmpv4MessageBody.into())
     }
 
@@ -368,7 +374,7 @@ pub trait Icmpv4Message {
     ///
     /// [`Icmpv4::downcast`]: Icmpv4::downcast
     /// [`msg_type`]: Icmpv4::msg_type
-    fn try_parse(icmp: Icmpv4, internal: Internal) -> Fallible<Self>
+    fn try_parse(icmp: Icmpv4, internal: Internal) -> Result<Self>
     where
         Self: Sized;
 
@@ -386,7 +392,7 @@ pub trait Icmpv4Message {
     ///
     /// [`msg_type`]: Icmpv4::msg_type
     /// [`Packet::push`]: Packet::push
-    fn try_push(icmp: Icmpv4, internal: Internal) -> Fallible<Self>
+    fn try_push(icmp: Icmpv4, internal: Internal) -> Result<Self>
     where
         Self: Sized;
 

--- a/core/src/packets/icmp/v4/mod.rs
+++ b/core/src/packets/icmp/v4/mod.rs
@@ -160,7 +160,7 @@ impl fmt::Debug for Icmpv4 {
 }
 
 /// Error when trying to push a generic ICMPv4 header without a message body.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 #[error("Cannot push a generic ICMPv4 header without a message body.")]
 pub struct NoIcmpv4MessageBody;
 

--- a/core/src/packets/icmp/v4/redirect.rs
+++ b/core/src/packets/icmp/v4/redirect.rs
@@ -20,7 +20,7 @@ use crate::packets::icmp::v4::{Icmpv4, Icmpv4Message, Icmpv4Packet, Icmpv4Type, 
 use crate::packets::ip::v4::IPV4_MIN_MTU;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::net::Ipv4Addr;
 use std::ptr::NonNull;
@@ -140,8 +140,14 @@ impl Icmpv4Message for Redirect {
         }
     }
 
+    /// Parses the ICMPv4 packet's payload as redirect.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the redirect message body.
     #[inline]
-    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -149,8 +155,14 @@ impl Icmpv4Message for Redirect {
         Ok(Redirect { icmp, body })
     }
 
+    /// Prepends a new redirect message to the beginning of the ICMPv4's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v4/time_exceeded.rs
+++ b/core/src/packets/icmp/v4/time_exceeded.rs
@@ -21,7 +21,7 @@ use crate::packets::ip::v4::IPV4_MIN_MTU;
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -115,8 +115,14 @@ impl Icmpv4Message for TimeExceeded {
         }
     }
 
+    /// Parses the ICMPv4 packet's payload as time exceeded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the time exceeded message body.
     #[inline]
-    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv4, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -124,8 +130,14 @@ impl Icmpv4Message for TimeExceeded {
         Ok(TimeExceeded { icmp, body })
     }
 
+    /// Prepends a new time exceeded message to the beginning of the ICMPv4's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv4, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/echo_reply.rs
+++ b/core/src/packets/icmp/v6/echo_reply.rs
@@ -21,7 +21,7 @@ use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -115,8 +115,12 @@ impl<E: Ipv6Packet> EchoReply<E> {
     }
 
     /// Sets the data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.icmp_mut().mbuf_mut().resize(offset, len)?;
@@ -171,8 +175,14 @@ impl<E: Ipv6Packet> Icmpv6Message for EchoReply<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as echo reply.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the echo reply message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -180,8 +190,14 @@ impl<E: Ipv6Packet> Icmpv6Message for EchoReply<E> {
         Ok(EchoReply { icmp, body })
     }
 
+    /// Prepends a new echo reply message to the beginning of the ICMPv6's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/echo_request.rs
+++ b/core/src/packets/icmp/v6/echo_request.rs
@@ -21,7 +21,7 @@ use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -116,8 +116,12 @@ impl<E: Ipv6Packet> EchoRequest<E> {
     }
 
     /// Sets the data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    pub fn set_data(&mut self, data: &[u8]) -> Fallible<()> {
+    pub fn set_data(&mut self, data: &[u8]) -> Result<()> {
         let offset = self.data_offset();
         let len = data.len() as isize - self.data_len() as isize;
         self.icmp_mut().mbuf_mut().resize(offset, len)?;
@@ -172,8 +176,14 @@ impl<E: Ipv6Packet> Icmpv6Message for EchoRequest<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as echo request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the echo request message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -181,8 +191,14 @@ impl<E: Ipv6Packet> Icmpv6Message for EchoRequest<E> {
         Ok(EchoRequest { icmp, body })
     }
 
+    /// Prepends a new echo request message to the beginning of the ICMPv6's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -38,7 +38,6 @@ use crate::{ensure, SizeOf};
 use anyhow::{anyhow, Result};
 use std::fmt;
 use std::ptr::NonNull;
-use thiserror::Error;
 
 /// Internet Control Message Protocol v6 packet based on [IETF RFC 4443].
 ///
@@ -166,11 +165,6 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E> {
     }
 }
 
-/// Error when trying to push a generic ICMPv6 header without a message body.
-#[derive(Debug, Error)]
-#[error("Cannot push a generic ICMPv6 header without a message body.")]
-pub struct NoIcmpv6MessageBody;
-
 impl<E: Ipv6Packet> Packet for Icmpv6<E> {
     /// The preceding type for an ICMPv6 packet must be either an [IPv6]
     /// packet or any IPv6 extension packets.
@@ -236,15 +230,15 @@ impl<E: Ipv6Packet> Packet for Icmpv6<E> {
     }
 
     /// Cannot push a generic ICMPv6 header without a message body. This
-    /// will always return [`NoIcmpv6MessageBody`]. Instead, push a specific
-    /// message type like [`EchoRequest`], which includes the header and the
-    /// message body.
+    /// will always error. Instead, push a specific message type like
+    /// [`EchoRequest`], which includes the header and the message body.
     ///
-    /// [`NoIcmpv6MessageBody`]: NoIcmpv6MessageBody
     /// [`EchoRequest`]: EchoRequest
     #[inline]
     fn try_push(_envelope: Self::Envelope, _internal: crate::packets::Internal) -> Result<Self> {
-        Err(NoIcmpv6MessageBody.into())
+        Err(anyhow!(
+            "cannot push a generic ICMPv6 header without a message body."
+        ))
     }
 
     #[inline]

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -167,7 +167,7 @@ impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E> {
 }
 
 /// Error when trying to push a generic ICMPv6 header without a message body.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 #[error("Cannot push a generic ICMPv6 header without a message body.")]
 pub struct NoIcmpv6MessageBody;
 

--- a/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_advert.rs
@@ -22,7 +22,7 @@ use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::types::u16be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::net::Ipv6Addr;
 use std::ptr::NonNull;
@@ -209,8 +209,14 @@ impl<E: Ipv6Packet> Icmpv6Message for NeighborAdvertisement<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as neighbor advertisement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the neighbor advertisement message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -218,8 +224,14 @@ impl<E: Ipv6Packet> Icmpv6Message for NeighborAdvertisement<E> {
         Ok(NeighborAdvertisement { icmp, body })
     }
 
+    /// Prepends a new neighbor advertisement message to the beginning of
+    /// the ICMPv6's payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/neighbor_solicit.rs
@@ -22,7 +22,7 @@ use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::net::Ipv6Addr;
 use std::ptr::NonNull;
@@ -128,8 +128,14 @@ impl<E: Ipv6Packet> Icmpv6Message for NeighborSolicitation<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as neighbor solicitation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the neighbor solicitation message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -137,8 +143,14 @@ impl<E: Ipv6Packet> Icmpv6Message for NeighborSolicitation<E> {
         Ok(NeighborSolicitation { icmp, body })
     }
 
+    /// Prepends a new neighbor solicitation message to the beginning of
+    /// the ICMPv6's payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/ndp/redirect.rs
+++ b/core/src/packets/icmp/v6/ndp/redirect.rs
@@ -22,7 +22,7 @@ use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::net::Ipv6Addr;
 use std::ptr::NonNull;
@@ -153,8 +153,14 @@ impl<E: Ipv6Packet> Icmpv6Message for Redirect<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as redirect.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the redirect message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -162,8 +168,14 @@ impl<E: Ipv6Packet> Icmpv6Message for Redirect<E> {
         Ok(Redirect { icmp, body })
     }
 
+    /// Prepends a new redirect message to the beginning of the ICMPv6's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/ndp/router_advert.rs
+++ b/core/src/packets/icmp/v6/ndp/router_advert.rs
@@ -22,7 +22,7 @@ use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::types::{u16be, u32be};
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -250,8 +250,14 @@ impl<E: Ipv6Packet> Icmpv6Message for RouterAdvertisement<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as router advertisement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the router advertisement message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -259,8 +265,14 @@ impl<E: Ipv6Packet> Icmpv6Message for RouterAdvertisement<E> {
         Ok(RouterAdvertisement { icmp, body })
     }
 
+    /// Prepends a new router advertisement message to the beginning of
+    /// the ICMPv6's payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/ndp/router_solicit.rs
+++ b/core/src/packets/icmp/v6/ndp/router_solicit.rs
@@ -22,7 +22,7 @@ use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -96,8 +96,14 @@ impl<E: Ipv6Packet> Icmpv6Message for RouterSolicitation<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as router solicitation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the router solicitation message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -105,8 +111,14 @@ impl<E: Ipv6Packet> Icmpv6Message for RouterSolicitation<E> {
         Ok(RouterSolicitation { icmp, body })
     }
 
+    /// Prepends a new router solicitation message to the beginning of
+    /// the ICMPv6's payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/time_exceeded.rs
+++ b/core/src/packets/icmp/v6/time_exceeded.rs
@@ -21,7 +21,7 @@ use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -106,8 +106,14 @@ impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as time exceeded.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the time exceeded message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -115,8 +121,14 @@ impl<E: Ipv6Packet> Icmpv6Message for TimeExceeded<E> {
         Ok(TimeExceeded { icmp, body })
     }
 
+    /// Prepends a new time exceeded message to the beginning of the ICMPv6's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/icmp/v6/too_big.rs
+++ b/core/src/packets/icmp/v6/too_big.rs
@@ -21,7 +21,7 @@ use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
 use crate::packets::types::u32be;
 use crate::packets::{Internal, Packet};
 use crate::SizeOf;
-use failure::Fallible;
+use anyhow::Result;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -131,8 +131,14 @@ impl<E: Ipv6Packet> Icmpv6Message for PacketTooBig<E> {
         }
     }
 
+    /// Parses the ICMPv6 packet's payload as too big.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload does not have sufficient data for
+    /// the too big message body.
     #[inline]
-    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let mbuf = icmp.mbuf();
         let offset = icmp.payload_offset();
         let body = mbuf.read_data(offset)?;
@@ -140,8 +146,14 @@ impl<E: Ipv6Packet> Icmpv6Message for PacketTooBig<E> {
         Ok(PacketTooBig { icmp, body })
     }
 
+    /// Prepends a new too big message to the beginning of the ICMPv6's
+    /// payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
     #[inline]
-    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut icmp: Icmpv6<Self::Envelope>, _internal: Internal) -> Result<Self> {
         let offset = icmp.payload_offset();
         let mbuf = icmp.mbuf_mut();
 

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -26,7 +26,6 @@ use crate::packets::Packet;
 use anyhow::Result;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
-use thiserror::Error;
 
 /// [IANA] recommended default TTL for IP.
 ///
@@ -263,18 +262,6 @@ impl fmt::Debug for Flow {
             .field("protocol", &format!("{}", self.protocol()))
             .finish()
     }
-}
-
-/// IP packet related errors.
-#[derive(Debug, Error)]
-pub enum IpPacketError {
-    /// Error indicating mixing IPv4 and IPv6 addresses in a flow.
-    #[error("Cannot mix IPv4 and IPv6 addresses")]
-    IpAddrMismatch,
-
-    /// Error indicating the MTU is less than the minimum MTU size.
-    #[error("{0} is less than the minimum MTU of {1}.")]
-    MtuTooSmall(usize, usize),
 }
 
 #[cfg(test)]

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -23,9 +23,10 @@ pub mod v6;
 
 use crate::packets::checksum::PseudoHeader;
 use crate::packets::Packet;
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
+use thiserror::Error;
 
 /// [IANA] recommended default TTL for IP.
 ///
@@ -119,7 +120,7 @@ pub trait IpPacket: Packet {
     ///
     /// This lets an upper layer packet like TCP set the source IP address.
     /// on a lower layer packet.
-    fn set_src(&mut self, src: IpAddr) -> Fallible<()>;
+    fn set_src(&mut self, src: IpAddr) -> Result<()>;
 
     /// Returns the destination IP address
     fn dst(&self) -> IpAddr;
@@ -128,13 +129,13 @@ pub trait IpPacket: Packet {
     ///
     /// This lets an upper layer packet like TCP set the destination IP address
     /// on a lower layer packet.
-    fn set_dst(&mut self, dst: IpAddr) -> Fallible<()>;
+    fn set_dst(&mut self, dst: IpAddr) -> Result<()>;
 
     /// Returns the pseudo-header for layer 4 checksum computation.
     fn pseudo_header(&self, packet_len: u16, protocol: ProtocolNumber) -> PseudoHeader;
 
     /// Truncates the IP packet to MTU. The data exceeds MTU is lost.
-    fn truncate(&mut self, mtu: usize) -> Fallible<()>;
+    fn truncate(&mut self, mtu: usize) -> Result<()>;
 }
 
 /// The common attributes (5-tuple) used to identify an IP based network
@@ -265,14 +266,14 @@ impl fmt::Debug for Flow {
 }
 
 /// IP packet related errors.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum IpPacketError {
     /// Error indicating mixing IPv4 and IPv6 addresses in a flow.
-    #[fail(display = "Cannot mix IPv4 and IPv6 addresses")]
+    #[error("Cannot mix IPv4 and IPv6 addresses")]
     IpAddrMismatch,
 
     /// Error indicating the MTU is less than the minimum MTU size.
-    #[fail(display = "{} is less than the minimum MTU of {}.", _0, _1)]
+    #[error("{0} is less than the minimum MTU of {1}.")]
     MtuTooSmall(usize, usize),
 }
 

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -266,7 +266,7 @@ impl fmt::Debug for Flow {
 }
 
 /// IP packet related errors.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum IpPacketError {
     /// Error indicating mixing IPv4 and IPv6 addresses in a flow.
     #[error("Cannot mix IPv4 and IPv6 addresses")]

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -19,7 +19,7 @@
 //! Internet Protocol v4.
 
 use crate::packets::checksum::{self, PseudoHeader};
-use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
+use crate::packets::ip::{IpPacket, ProtocolNumber, DEFAULT_IP_TTL};
 use crate::packets::types::u16be;
 use crate::packets::{EtherTypes, Ethernet, Internal, Packet};
 use crate::{ensure, SizeOf};
@@ -509,7 +509,7 @@ impl IpPacket for Ipv4 {
     ///
     /// # Errors
     ///
-    /// Returns `IpPacketError::IpAddrMismatch` if `src` is not an Ipv4Addr.
+    /// Returns an error if `src` is not an Ipv4Addr.
     #[inline]
     fn set_src(&mut self, src: IpAddr) -> Result<()> {
         match src {
@@ -517,7 +517,7 @@ impl IpPacket for Ipv4 {
                 self.set_src(addr);
                 Ok(())
             }
-            _ => Err(IpPacketError::IpAddrMismatch.into()),
+            _ => Err(anyhow!("source address must be IPv4.")),
         }
     }
 
@@ -530,7 +530,7 @@ impl IpPacket for Ipv4 {
     ///
     /// # Errors
     ///
-    /// Returns `IpPacketError::IpAddrMismatch` if `dst` is not an Ipv4Addr.
+    /// Returns an error if `dst` is not an Ipv4Addr.
     #[inline]
     fn set_dst(&mut self, dst: IpAddr) -> Result<()> {
         match dst {
@@ -538,7 +538,7 @@ impl IpPacket for Ipv4 {
                 self.set_dst(addr);
                 Ok(())
             }
-            _ => Err(IpPacketError::IpAddrMismatch.into()),
+            _ => Err(anyhow!("destination address must be IPv4.")),
         }
     }
 
@@ -556,15 +556,14 @@ impl IpPacket for Ipv4 {
     ///
     /// # Errors
     ///
-    /// Returns `IpPacketError::MtuTooSmall` if the desired MTU is less
-    /// than [`IPV4_MIN_MTU`].
+    /// Returns an error if the desired MTU is less than [`IPV4_MIN_MTU`].
     ///
     /// [`IPV4_MIN_MTU`]: IPV4_MIN_MTU
     #[inline]
     fn truncate(&mut self, mtu: usize) -> Result<()> {
         ensure!(
             mtu >= IPV4_MIN_MTU,
-            IpPacketError::MtuTooSmall(mtu, IPV4_MIN_MTU)
+            anyhow!("MTU {} must be greater than {}.", mtu, IPV4_MIN_MTU)
         );
 
         // accounts for the Ethernet frame length.

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -27,9 +27,9 @@ pub use self::srh::*;
 use crate::packets::checksum::PseudoHeader;
 use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
 use crate::packets::types::{u16be, u32be};
-use crate::packets::{EtherTypes, Ethernet, Internal, Packet, ParseError};
+use crate::packets::{EtherTypes, Ethernet, Internal, Packet};
 use crate::{ensure, SizeOf};
-use failure::Fallible;
+use anyhow::{anyhow, Result};
 use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
@@ -262,16 +262,19 @@ impl Packet for Ipv6 {
 
     /// Parses the Ethernet's payload as an IPv6 packet.
     ///
-    /// [`ether_type`] must be set to [`EtherTypes::Ipv6`]. Otherwise a
-    /// parsing error is returned.
+    /// # Errors
+    ///
+    /// Returns an error if [`ether_type`] is not set to [`EtherTypes::Ipv6`].
+    /// Returns an error if the payload does not have sufficient data for the
+    /// IPv6 header.
     ///
     /// [`ether_type`]: Ethernet::ether_type
     /// [`EtherTypes::Ipv6`]: EtherTypes::Ipv6
     #[inline]
-    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         ensure!(
             envelope.ether_type() == EtherTypes::Ipv6,
-            ParseError::new("not an IPv6 packet.")
+            anyhow!("not an IPv6 packet.")
         );
 
         let mbuf = envelope.mbuf();
@@ -289,10 +292,14 @@ impl Packet for Ipv6 {
     ///
     /// [`ether_type`] is set to [`EtherTypes::Ipv6`].
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
+    ///
     /// [`ether_type`]: Ethernet::ether_type
     /// [`EtherTypes::Ipv6`]: EtherTypes::Ipv6
     #[inline]
-    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         let offset = envelope.payload_offset();
         let mbuf = envelope.mbuf_mut();
 
@@ -343,8 +350,13 @@ impl IpPacket for Ipv6 {
         IpAddr::V6(self.src())
     }
 
+    /// Sets the source IP address.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IpPacketError::IpAddrMismatch` if `src` is not an Ipv6Addr.
     #[inline]
-    fn set_src(&mut self, src: IpAddr) -> Fallible<()> {
+    fn set_src(&mut self, src: IpAddr) -> Result<()> {
         match src {
             IpAddr::V6(addr) => {
                 self.set_src(addr);
@@ -359,8 +371,13 @@ impl IpPacket for Ipv6 {
         IpAddr::V6(self.dst())
     }
 
+    /// Sets the destination IP address.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IpPacketError::IpAddrMismatch` if `dst` is not an Ipv6Addr.
     #[inline]
-    fn set_dst(&mut self, dst: IpAddr) -> Fallible<()> {
+    fn set_dst(&mut self, dst: IpAddr) -> Result<()> {
         match dst {
             IpAddr::V6(addr) => {
                 self.set_dst(addr);
@@ -380,8 +397,16 @@ impl IpPacket for Ipv6 {
         }
     }
 
+    /// Truncates the IP packet to a maximum transmission unit size.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IpPacketError::MtuTooSmall` if the desired MTU is less
+    /// than [`IPV6_MIN_MTU`].
+    ///
+    /// [`IPV6_MIN_MTU`]: IPV6_MIN_MTU
     #[inline]
-    fn truncate(&mut self, mtu: usize) -> Fallible<()> {
+    fn truncate(&mut self, mtu: usize) -> Result<()> {
         ensure!(
             mtu >= IPV6_MIN_MTU,
             IpPacketError::MtuTooSmall(mtu, IPV6_MIN_MTU)

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -25,7 +25,7 @@ pub use self::fragment::*;
 pub use self::srh::*;
 
 use crate::packets::checksum::PseudoHeader;
-use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
+use crate::packets::ip::{IpPacket, ProtocolNumber, DEFAULT_IP_TTL};
 use crate::packets::types::{u16be, u32be};
 use crate::packets::{EtherTypes, Ethernet, Internal, Packet};
 use crate::{ensure, SizeOf};
@@ -354,7 +354,7 @@ impl IpPacket for Ipv6 {
     ///
     /// # Errors
     ///
-    /// Returns `IpPacketError::IpAddrMismatch` if `src` is not an Ipv6Addr.
+    /// Returns an error if `src` is not an Ipv6Addr.
     #[inline]
     fn set_src(&mut self, src: IpAddr) -> Result<()> {
         match src {
@@ -362,7 +362,7 @@ impl IpPacket for Ipv6 {
                 self.set_src(addr);
                 Ok(())
             }
-            _ => Err(IpPacketError::IpAddrMismatch.into()),
+            _ => Err(anyhow!("source address must be IPv6.")),
         }
     }
 
@@ -375,7 +375,7 @@ impl IpPacket for Ipv6 {
     ///
     /// # Errors
     ///
-    /// Returns `IpPacketError::IpAddrMismatch` if `dst` is not an Ipv6Addr.
+    /// Returns an error if `dst` is not an Ipv6Addr.
     #[inline]
     fn set_dst(&mut self, dst: IpAddr) -> Result<()> {
         match dst {
@@ -383,7 +383,7 @@ impl IpPacket for Ipv6 {
                 self.set_dst(addr);
                 Ok(())
             }
-            _ => Err(IpPacketError::IpAddrMismatch.into()),
+            _ => Err(anyhow!("destination address must be IPv6.")),
         }
     }
 
@@ -401,15 +401,14 @@ impl IpPacket for Ipv6 {
     ///
     /// # Errors
     ///
-    /// Returns `IpPacketError::MtuTooSmall` if the desired MTU is less
-    /// than [`IPV6_MIN_MTU`].
+    /// Returns an error if the desired MTU is less than [`IPV6_MIN_MTU`].
     ///
     /// [`IPV6_MIN_MTU`]: IPV6_MIN_MTU
     #[inline]
     fn truncate(&mut self, mtu: usize) -> Result<()> {
         ensure!(
             mtu >= IPV6_MIN_MTU,
-            IpPacketError::MtuTooSmall(mtu, IPV6_MIN_MTU)
+            anyhow!("MTU {} must be greater than {}.", mtu, IPV6_MIN_MTU)
         );
 
         // accounts for the Ethernet frame length.

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -26,7 +26,6 @@ use anyhow::{anyhow, Result};
 use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
-use thiserror::Error;
 
 /// IPv6 Segment Routing based on [IETF DRAFT].
 ///
@@ -205,8 +204,8 @@ impl<E: Ipv6Packet> SegmentRouting<E> {
     ///
     /// # Errors
     ///
-    /// Returns `BadSegmentsError` if the segments length is 0. Returns an
-    /// error if the buffer does not have enough free space for the segments.
+    /// Returns an error if the segments length is 0. Returns an error if the
+    /// buffer does not have enough free space for the segments.
     #[inline]
     pub fn set_segments(&mut self, segments: &[Ipv6Addr]) -> Result<()> {
         if !segments.is_empty() {
@@ -229,7 +228,7 @@ impl<E: Ipv6Packet> SegmentRouting<E> {
             self.set_last_entry(new_len - 1);
             Ok(())
         } else {
-            Err(BadSegmentsError.into())
+            Err(anyhow!("segment list length must be greater than 0."))
         }
     }
 }
@@ -490,11 +489,6 @@ impl<E: Ipv6Packet> Ipv6Packet for SegmentRouting<E> {
         self.header_mut().next_header = next_header.0;
     }
 }
-
-/// Error when the segment list length is 0.
-#[derive(Debug, Error)]
-#[error("Segment list length must be greater than 0")]
-pub struct BadSegmentsError;
 
 /// IPv6 segment routing header.
 ///

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -492,7 +492,7 @@ impl<E: Ipv6Packet> Ipv6Packet for SegmentRouting<E> {
 }
 
 /// Error when the segment list length is 0.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 #[error("Segment list length must be greater than 0")]
 pub struct BadSegmentsError;
 

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -20,12 +20,13 @@ use crate::packets::checksum::PseudoHeader;
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::ip::{IpPacket, ProtocolNumber, ProtocolNumbers};
 use crate::packets::types::u16be;
-use crate::packets::{Internal, Packet, ParseError};
+use crate::packets::{Internal, Packet};
 use crate::{ensure, SizeOf};
-use failure::{Fail, Fallible};
+use anyhow::{anyhow, Result};
 use std::fmt;
 use std::net::{IpAddr, Ipv6Addr};
 use std::ptr::NonNull;
+use thiserror::Error;
 
 /// IPv6 Segment Routing based on [IETF DRAFT].
 ///
@@ -201,8 +202,13 @@ impl<E: Ipv6Packet> SegmentRouting<E> {
     /// Be aware that when invoking this function, it can affect Tcp and Udp
     /// checksum calculations, as the last segment is used as part of the
     /// pseudo header.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BadSegmentsError` if the segments length is 0. Returns an
+    /// error if the buffer does not have enough free space for the segments.
     #[inline]
-    pub fn set_segments(&mut self, segments: &[Ipv6Addr]) -> Fallible<()> {
+    pub fn set_segments(&mut self, segments: &[Ipv6Addr]) -> Result<()> {
         if !segments.is_empty() {
             let old_len = self.last_entry() + 1;
             let new_len = segments.len() as u8;
@@ -282,16 +288,19 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
 
     /// Parses the envelope's payload as an IPv6 segment routing packet.
     ///
-    /// [`next_header`] of the envelope must be set to [`ProtocolNumbers::Ipv6Route`].
-    /// Otherwise a parsing error is returned.
+    /// # Errors
+    ///
+    /// Returns an error if [`next_header`] is not set to [`ProtocolNumbers::Ipv6Route`].
+    /// Returns an error if the payload does not have sufficient data for the
+    /// segment routing extension header or the segment length is inconsistent.
     ///
     /// [`next_header`]: Ipv6Packet::next_header
     /// [`ProtocolNumbers::Ipv6Route`]: ProtocolNumbers::Ipv6Route
     #[inline]
-    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         ensure!(
             envelope.next_header() == ProtocolNumbers::Ipv6Route,
-            ParseError::new("not an IPv6 routing packet.")
+            anyhow!("not an IPv6 routing packet.")
         );
 
         let mbuf = envelope.mbuf();
@@ -314,7 +323,7 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
                 offset,
             })
         } else {
-            Err(ParseError::new("Packet has inconsistent segment list length.").into())
+            Err(anyhow!("Packet has inconsistent segment list length."))
         }
     }
 
@@ -324,10 +333,14 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
     /// [`next_header`] is set to the value of the `next_header` field of the
     /// envelope, and the envelope is set to [`ProtocolNumbers::Ipv6Route`].
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
+    ///
     /// [`next_header`]: Ipv6Packet::next_header
     /// [`ProtocolNumbers::Ipv6Route`]: ProtocolNumbers::Ipv6Route
     #[inline]
-    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         let offset = envelope.payload_offset();
         let mbuf = envelope.mbuf_mut();
 
@@ -362,9 +375,14 @@ impl<E: Ipv6Packet> Packet for SegmentRouting<E> {
     /// The envelope's [`next_header`] field is set to the value of the
     /// `next_header` field on the segment routing packet.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have sufficient data to
+    /// remove.
+    ///
     /// [`next_header`]: Ipv6Packet::next_header
     #[inline]
-    fn remove(mut self) -> Fallible<Self::Envelope> {
+    fn remove(mut self) -> Result<Self::Envelope> {
         let offset = self.offset();
         let len = self.header_len();
         let next_header = self.next_header();
@@ -396,7 +414,7 @@ impl<E: Ipv6Packet> IpPacket for SegmentRouting<E> {
     }
 
     #[inline]
-    fn set_src(&mut self, src: IpAddr) -> Fallible<()> {
+    fn set_src(&mut self, src: IpAddr) -> Result<()> {
         self.envelope_mut().set_src(src)
     }
 
@@ -406,7 +424,7 @@ impl<E: Ipv6Packet> IpPacket for SegmentRouting<E> {
     }
 
     #[inline]
-    fn set_dst(&mut self, dst: IpAddr) -> Fallible<()> {
+    fn set_dst(&mut self, dst: IpAddr) -> Result<()> {
         if let IpAddr::V6(v6_dst) = dst {
             let mut segments = vec![v6_dst];
             for segment in self.segments().iter().skip(1) {
@@ -456,7 +474,7 @@ impl<E: Ipv6Packet> IpPacket for SegmentRouting<E> {
     }
 
     #[inline]
-    fn truncate(&mut self, mtu: usize) -> Fallible<()> {
+    fn truncate(&mut self, mtu: usize) -> Result<()> {
         self.envelope_mut().truncate(mtu)
     }
 }
@@ -474,8 +492,8 @@ impl<E: Ipv6Packet> Ipv6Packet for SegmentRouting<E> {
 }
 
 /// Error when the segment list length is 0.
-#[derive(Debug, Fail)]
-#[fail(display = "Segment list length must be greater than 0")]
+#[derive(Error, Debug)]
+#[error("Segment list length must be greater than 0")]
 pub struct BadSegmentsError;
 
 /// IPv6 segment routing header.

--- a/core/src/packets/mod.rs
+++ b/core/src/packets/mod.rs
@@ -21,7 +21,7 @@
 pub mod arp;
 pub mod checksum;
 mod ethernet;
-//pub mod icmp;
+pub mod icmp;
 pub mod ip;
 mod tcp;
 pub mod types;

--- a/core/src/packets/tcp.rs
+++ b/core/src/packets/tcp.rs
@@ -20,9 +20,9 @@ use crate::packets::ip::v4::Ipv4;
 use crate::packets::ip::v6::Ipv6;
 use crate::packets::ip::{Flow, IpPacket, ProtocolNumbers};
 use crate::packets::types::{u16be, u32be};
-use crate::packets::{checksum, Internal, Packet, ParseError};
+use crate::packets::{checksum, Internal, Packet};
 use crate::{ensure, SizeOf};
-use failure::Fallible;
+use anyhow::{anyhow, Result};
 use std::fmt;
 use std::net::IpAddr;
 use std::ptr::NonNull;
@@ -421,8 +421,15 @@ impl<E: IpPacket> Tcp<E> {
     /// It recomputes the checksum using the incremental method. This is more
     /// efficient if the only change made is the address. Otherwise should use
     /// `cascade` to recompute the checksum over all the fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IpPacketError::IpAddrMismatch` if `src_ip` address type
+    /// does not match the address type of the envelope. For example, if
+    /// the TCP packet is inside a IPv6 packet, the `src_ip` must be an
+    /// Ipv6Addr.
     #[inline]
-    pub fn set_src_ip(&mut self, src_ip: IpAddr) -> Fallible<()> {
+    pub fn set_src_ip(&mut self, src_ip: IpAddr) -> Result<()> {
         let old_ip = self.envelope().src();
         let checksum = checksum::compute_with_ipaddr(self.checksum(), &old_ip, &src_ip)?;
         self.envelope_mut().set_src(src_ip)?;
@@ -435,8 +442,15 @@ impl<E: IpPacket> Tcp<E> {
     /// It recomputes the checksum using the incremental method. This is more
     /// efficient if the only change made is the address. Otherwise should use
     /// `cascade` to recompute the checksum over all the fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IpPacketError::IpAddrMismatch` if `dst_ip` address type
+    /// does not match the address type of the envelope. For example, if
+    /// the TCP packet is inside a IPv6 packet, the `dst_ip` must be an
+    /// Ipv6Addr.
     #[inline]
-    pub fn set_dst_ip(&mut self, dst_ip: IpAddr) -> Fallible<()> {
+    pub fn set_dst_ip(&mut self, dst_ip: IpAddr) -> Result<()> {
         let old_ip = self.envelope().dst();
         let checksum = checksum::compute_with_ipaddr(self.checksum(), &old_ip, &dst_ip)?;
         self.envelope_mut().set_dst(dst_ip)?;
@@ -529,19 +543,22 @@ impl<E: IpPacket> Packet for Tcp<E> {
 
     /// Parses the envelope's payload as a TCP packet.
     ///
-    /// If the envelope is IPv4, then [`Ipv4::protocol`] must be set to
-    /// [`ProtocolNumbers::Tcp`]. If the envelope is IPv6 or an extension
-    /// header, then [`next_header`] must be set to `ProtocolNumbers::Tcp`.
-    /// Otherwise, a parsing error is returned.
+    /// # Errors
+    ///
+    /// If the envelope is IPv4, returns an error if [`Ipv4::protocol`] is
+    /// not set to [`ProtocolNumbers::Tcp`]. If the envelope is IPv6 or an
+    /// extension header, returns an error if [`next_header`] is not set to
+    /// `ProtocolNumbers::Tcp`. Returns an error if the payload does not
+    /// have sufficient data for the TCP header.
     ///
     /// [`Ipv4::protocol`]: crate::packets::ip::v4::Ipv4::protocol
     /// [`ProtocolNumbers::Tcp`]: crate::packets::ip::ProtocolNumbers::Tcp
     /// [`next_header`]: crate::packets::ip::v6::Ipv6Packet::next_header
     #[inline]
-    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_parse(envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         ensure!(
             envelope.next_protocol() == ProtocolNumbers::Tcp,
-            ParseError::new("not a TCP packet.")
+            anyhow!("not a TCP packet.")
         );
 
         let mbuf = envelope.mbuf();
@@ -561,11 +578,15 @@ impl<E: IpPacket> Packet for Tcp<E> {
     /// [`ProtocolNumbers::Tcp`]. If the envelope is IPv6 or an extension
     /// header, then [`next_header`] is set to `ProtocolNumbers::Tcp`.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer does not have enough free space.
+    ///
     /// [`Ipv4::protocol`]: crate::packets::ip::v4::Ipv4::protocol
     /// [`ProtocolNumbers::Tcp`]: crate::packets::ip::ProtocolNumbers::Tcp
     /// [`next_header`]: crate::packets::ip::v6::Ipv6Packet::next_header
     #[inline]
-    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Fallible<Self> {
+    fn try_push(mut envelope: Self::Envelope, _internal: Internal) -> Result<Self> {
         let offset = envelope.payload_offset();
         let mbuf = envelope.mbuf_mut();
 

--- a/core/src/pcap.rs
+++ b/core/src/pcap.rs
@@ -33,7 +33,7 @@ const PCAP_SNAPSHOT_LEN: raw::c_int = ffi::RTE_MBUF_DEFAULT_BUF_SIZE as raw::c_i
 ///
 /// When an FFI call fails, either a specified error message or an `errno` is
 /// translated into a `PcapError`.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 #[error("{0}")]
 struct PcapError(String);
 

--- a/core/src/pcap.rs
+++ b/core/src/pcap.rs
@@ -19,10 +19,11 @@
 use crate::dpdk::{CoreId, DpdkError, PortId, RxTxQueue};
 use crate::ffi::{self, AsStr, ToCString, ToResult};
 use crate::{debug, error};
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use std::fmt;
 use std::os::raw;
 use std::ptr::NonNull;
+use thiserror::Error;
 
 // DLT_EN10MB; LINKTYPE_ETHERNET=1; 10MB is historical
 const DLT_EN10MB: raw::c_int = 1;
@@ -32,8 +33,8 @@ const PCAP_SNAPSHOT_LEN: raw::c_int = ffi::RTE_MBUF_DEFAULT_BUF_SIZE as raw::c_i
 ///
 /// When an FFI call fails, either a specified error message or an `errno` is
 /// translated into a `PcapError`.
-#[derive(Debug, Fail)]
-#[fail(display = "{}", _0)]
+#[derive(Error, Debug)]
+#[error("{0}")]
 struct PcapError(String);
 
 impl PcapError {
@@ -60,7 +61,7 @@ struct Pcap {
 
 impl Pcap {
     /// Creates a file for dumping packets into from a given file path.
-    fn create(path: &str) -> Fallible<Pcap> {
+    fn create(path: &str) -> Result<Pcap> {
         unsafe {
             let handle = ffi::pcap_open_dead(DLT_EN10MB, PCAP_SNAPSHOT_LEN)
                 .to_result(|_| PcapError::new("Cannot create packet capture handle."))?;
@@ -83,7 +84,7 @@ impl Pcap {
 
     /// Append to already-existing file for dumping packets into from a given
     /// file path.
-    fn append(path: &str) -> Fallible<Pcap> {
+    fn append(path: &str) -> Result<Pcap> {
         if !std::path::Path::new(path).exists() {
             return Err(PcapError::new("Pcap filename path does not exist.").into());
         }
@@ -106,13 +107,13 @@ impl Pcap {
     }
 
     /// Write packets to `pcap` file handler.
-    unsafe fn write(&self, ptrs: &[*mut ffi::rte_mbuf]) -> Fallible<()> {
+    unsafe fn write(&self, ptrs: &[*mut ffi::rte_mbuf]) -> Result<()> {
         ptrs.iter().try_for_each(|&p| self.dump_packet(p))?;
 
         self.flush()
     }
 
-    unsafe fn dump_packet(&self, ptr: *mut ffi::rte_mbuf) -> Fallible<()> {
+    unsafe fn dump_packet(&self, ptr: *mut ffi::rte_mbuf) -> Result<()> {
         let mut pcap_hdr = ffi::pcap_pkthdr::default();
         pcap_hdr.len = (*ptr).data_len as u32;
         pcap_hdr.caplen = pcap_hdr.len;
@@ -132,7 +133,7 @@ impl Pcap {
         Ok(())
     }
 
-    fn flush(&self) -> Fallible<()> {
+    fn flush(&self) -> Result<()> {
         unsafe {
             ffi::pcap_dump_flush(self.dumper.as_ptr())
                 .to_result(|_| PcapError::new("Cannot flush packets to packet capture"))
@@ -167,7 +168,7 @@ pub(crate) fn capture_queue(
     port_name: &str,
     core: CoreId,
     q: RxTxQueue,
-) -> Fallible<()> {
+) -> Result<()> {
     match q {
         RxTxQueue::Rx(rxq) => {
             Pcap::create(&format_pcap_file(port_name, core.raw(), "rx"))?;

--- a/core/src/runtime/core_map.rs
+++ b/core/src/runtime/core_map.rs
@@ -18,11 +18,12 @@
 
 use crate::dpdk::{CoreId, Mempool, MempoolMap, MEMPOOL};
 use crate::{debug, error, ffi, info};
-use failure::{Fail, Fallible};
+use anyhow::Result;
 use futures::Future;
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::{self, JoinHandle};
+use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio_executor::current_thread::{self, CurrentThread};
 use tokio_executor::park::ParkThread;
@@ -148,14 +149,14 @@ pub(crate) struct CoreExecutor {
 }
 
 /// Core errors.
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub(crate) enum CoreError {
     /// Core is not found.
-    #[fail(display = "{:?} is not found.", _0)]
+    #[error("{0:?} is not found.")]
     NotFound(CoreId),
 
     /// Core is not assigned to any ports.
-    #[fail(display = "{:?} is not assigned to any ports.", _0)]
+    #[error("{0:?} is not assigned to any ports.")]
     NotAssigned(CoreId),
 }
 
@@ -212,7 +213,7 @@ impl<'a> CoreMapBuilder<'a> {
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub(crate) fn finish(&'a mut self) -> Fallible<CoreMap> {
+    pub(crate) fn finish(&'a mut self) -> Result<CoreMap> {
         let mut map = HashMap::new();
 
         // first initializes the master core, which the current running
@@ -301,7 +302,7 @@ impl<'a> CoreMapBuilder<'a> {
 fn init_master_core(
     id: CoreId,
     mempool: *mut ffi::rte_mempool,
-) -> Fallible<(MasterExecutor, CoreExecutor)> {
+) -> Result<(MasterExecutor, CoreExecutor)> {
     // affinitize the running thread to this core.
     id.set_thread_affinity()?;
 
@@ -341,7 +342,7 @@ fn init_master_core(
 fn init_background_core(
     id: CoreId,
     mempool: *mut ffi::rte_mempool,
-) -> Fallible<(
+) -> Result<(
     CurrentThread<Timer<ParkThread>>,
     Park,
     Shutdown,

--- a/core/src/runtime/core_map.rs
+++ b/core/src/runtime/core_map.rs
@@ -149,7 +149,7 @@ pub(crate) struct CoreExecutor {
 }
 
 /// Core errors.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub(crate) enum CoreError {
     /// Core is not found.
     #[error("{0:?} is not found.")]

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -26,7 +26,7 @@ use crate::dpdk::{
     self, CoreId, KniError, KniRx, Mempool, Port, PortBuilder, PortError, PortQueue,
 };
 use crate::{debug, ensure, info};
-use failure::Fallible;
+use anyhow::Result;
 use futures::{future, stream, StreamExt};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -78,7 +78,7 @@ pub struct Runtime {
 impl Runtime {
     /// Builds a runtime from config settings.
     #[allow(clippy::cognitive_complexity)]
-    pub fn build(config: RuntimeConfig) -> Fallible<Self> {
+    pub fn build(config: RuntimeConfig) -> Result<Self> {
         info!("initializing EAL...");
         dpdk::eal_init(config.to_eal_args())?;
 
@@ -144,7 +144,7 @@ impl Runtime {
     }
 
     #[inline]
-    fn get_port(&self, name: &str) -> Fallible<&Port> {
+    fn get_port(&self, name: &str) -> Result<&Port> {
         self.ports
             .iter()
             .find(|p| p.name() == name)
@@ -152,7 +152,7 @@ impl Runtime {
     }
 
     #[inline]
-    fn get_port_mut(&mut self, name: &str) -> Fallible<&mut Port> {
+    fn get_port_mut(&mut self, name: &str) -> Result<&mut Port> {
         self.ports
             .iter_mut()
             .find(|p| p.name() == name)
@@ -160,7 +160,7 @@ impl Runtime {
     }
 
     #[inline]
-    fn get_core(&self, core_id: CoreId) -> Fallible<&CoreExecutor> {
+    fn get_core(&self, core_id: CoreId) -> Result<&CoreExecutor> {
         self.core_map
             .cores
             .get(&core_id)
@@ -168,7 +168,7 @@ impl Runtime {
     }
 
     #[inline]
-    fn get_port_qs(&self, core_id: CoreId) -> Fallible<HashMap<String, PortQueue>> {
+    fn get_port_qs(&self, core_id: CoreId) -> Result<HashMap<String, PortQueue>> {
         let map = self
             .ports
             .iter()
@@ -234,7 +234,7 @@ impl Runtime {
         &mut self,
         port: &str,
         installer: F,
-    ) -> Fallible<&mut Self>
+    ) -> Result<&mut Self>
     where
         F: Fn(PortQueue) -> T + Send + Sync + 'static,
     {
@@ -288,7 +288,7 @@ impl Runtime {
         &mut self,
         port: &str,
         installer: F,
-    ) -> Fallible<&mut Self>
+    ) -> Result<&mut Self>
     where
         F: FnOnce(KniRx, PortQueue) -> T + Send + Sync + 'static,
     {
@@ -342,7 +342,7 @@ impl Runtime {
         &mut self,
         core: usize,
         installer: F,
-    ) -> Fallible<&mut Self>
+    ) -> Result<&mut Self>
     where
         F: FnOnce(HashMap<String, PortQueue>) -> T + Send + Sync + 'static,
     {
@@ -393,7 +393,7 @@ impl Runtime {
         core: usize,
         installer: F,
         dur: Duration,
-    ) -> Fallible<&mut Self>
+    ) -> Result<&mut Self>
     where
         F: FnOnce(HashMap<String, PortQueue>) -> T + Send + Sync + 'static,
     {
@@ -436,7 +436,7 @@ impl Runtime {
         core: usize,
         task: F,
         dur: Duration,
-    ) -> Fallible<&mut Self>
+    ) -> Result<&mut Self>
     where
         F: Fn() + Send + Sync + 'static,
     {
@@ -464,7 +464,7 @@ impl Runtime {
     ///
     /// This mode is useful for running integration tests. The timeout
     /// duration can be set in `RuntimeSettings`.
-    fn wait_for_timeout(&mut self, timeout: Duration) -> Fallible<()> {
+    fn wait_for_timeout(&mut self, timeout: Duration) -> Result<()> {
         let MasterExecutor {
             ref timer,
             ref mut thread,
@@ -483,7 +483,7 @@ impl Runtime {
     }
 
     /// Blocks the main thread until receives a signal to terminate.
-    fn wait_for_signal(&mut self) -> Fallible<()> {
+    fn wait_for_signal(&mut self) -> Result<()> {
         let sighup = unix::signal(SignalKind::hangup())?.map(|_| UnixSignal::SIGHUP);
         let sigint = unix::signal(SignalKind::interrupt())?.map(|_| UnixSignal::SIGINT);
         let sigterm = unix::signal(SignalKind::terminate())?.map(|_| UnixSignal::SIGTERM);
@@ -516,7 +516,7 @@ impl Runtime {
     }
 
     /// Installs the KNI TX pipelines.
-    fn add_kni_tx_pipelines(&mut self) -> Fallible<()> {
+    fn add_kni_tx_pipelines(&mut self) -> Result<()> {
         let mut map = HashMap::new();
         for port in self.ports.iter_mut() {
             // selects a core if we need to run a tx pipeline for this port. the
@@ -544,7 +544,7 @@ impl Runtime {
     }
 
     /// Starts all the ports to receive packets.
-    fn start_ports(&mut self) -> Fallible<()> {
+    fn start_ports(&mut self) -> Result<()> {
         for port in self.ports.iter_mut() {
             port.start()?;
         }
@@ -584,7 +584,7 @@ impl Runtime {
     }
 
     /// Executes the pipeline(s) until a stop signal is received.
-    pub fn execute(&mut self) -> Fallible<()> {
+    pub fn execute(&mut self) -> Result<()> {
         self.add_kni_tx_pipelines()?;
         self.start_ports()?;
         self.unpark_cores();

--- a/examples/kni/Cargo.toml
+++ b/examples/kni/Cargo.toml
@@ -16,8 +16,8 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
-failure = "0.1"
 metrics-core = "0.5"
 metrics-observer-yaml = "0.1"
 tracing = "0.1"

--- a/examples/kni/main.rs
+++ b/examples/kni/main.rs
@@ -16,10 +16,10 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::config::load_config;
 use capsule::metrics;
 use capsule::{batch, Runtime};
-use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
 use metrics_observer_yaml::YamlBuilder;
 use std::time::Duration;
@@ -32,7 +32,7 @@ fn print_stats() {
     println!("{}", observer.drain());
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .finish();

--- a/examples/nat64/Cargo.toml
+++ b/examples/nat64/Cargo.toml
@@ -16,9 +16,9 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
 chashmap = "2.2"
-failure = "0.1"
 once_cell = "1.2"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/ping4d/Cargo.toml
+++ b/examples/ping4d/Cargo.toml
@@ -16,7 +16,7 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
-failure = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/ping4d/main.rs
+++ b/examples/ping4d/main.rs
@@ -16,17 +16,17 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::batch::{Batch, Pipeline, Poll};
 use capsule::config::load_config;
 use capsule::packets::icmp::v4::{EchoReply, EchoRequest};
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::{Ethernet, Packet};
 use capsule::{Mbuf, PortQueue, Runtime};
-use failure::Fallible;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
-fn reply_echo(packet: &Mbuf) -> Fallible<EchoReply> {
+fn reply_echo(packet: &Mbuf) -> Result<EchoReply> {
     let reply = Mbuf::new()?;
 
     let ethernet = packet.peek::<Ethernet>()?;
@@ -57,7 +57,7 @@ fn install(q: PortQueue) -> impl Pipeline {
     Poll::new(q.clone()).replace(reply_echo).send(q)
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .finish();

--- a/examples/pktdump/Cargo.toml
+++ b/examples/pktdump/Cargo.toml
@@ -16,8 +16,8 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
 colored = "2.0"
-failure = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/pktdump/main.rs
+++ b/examples/pktdump/main.rs
@@ -16,6 +16,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::batch::{Batch, Pipeline, Poll};
 use capsule::config::load_config;
 use capsule::packets::ip::v4::Ipv4;
@@ -24,12 +25,11 @@ use capsule::packets::ip::IpPacket;
 use capsule::packets::{EtherTypes, Ethernet, Packet, Tcp, Tcp4, Tcp6};
 use capsule::{compose, Mbuf, PortQueue, Runtime};
 use colored::*;
-use failure::Fallible;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
 #[inline]
-fn dump_eth(packet: Mbuf) -> Fallible<Ethernet> {
+fn dump_eth(packet: Mbuf) -> Result<Ethernet> {
     let ethernet = packet.parse::<Ethernet>()?;
 
     let info_fmt = format!("{:?}", ethernet).magenta().bold();
@@ -39,7 +39,7 @@ fn dump_eth(packet: Mbuf) -> Fallible<Ethernet> {
 }
 
 #[inline]
-fn dump_v4(ethernet: &Ethernet) -> Fallible<()> {
+fn dump_v4(ethernet: &Ethernet) -> Result<()> {
     let v4 = ethernet.peek::<Ipv4>()?;
     let info_fmt = format!("{:?}", v4).yellow();
     println!("{}", info_fmt);
@@ -51,7 +51,7 @@ fn dump_v4(ethernet: &Ethernet) -> Fallible<()> {
 }
 
 #[inline]
-fn dump_v6(ethernet: &Ethernet) -> Fallible<()> {
+fn dump_v6(ethernet: &Ethernet) -> Result<()> {
     let v6 = ethernet.peek::<Ipv6>()?;
     let info_fmt = format!("{:?}", v6).cyan();
     println!("{}", info_fmt);
@@ -90,7 +90,7 @@ fn install(q: PortQueue) -> impl Pipeline {
         .send(q)
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::DEBUG)
         .finish();

--- a/examples/signals/Cargo.toml
+++ b/examples/signals/Cargo.toml
@@ -16,7 +16,7 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
-failure = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/signals/main.rs
+++ b/examples/signals/main.rs
@@ -16,10 +16,10 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::config::load_config;
 use capsule::Runtime;
 use capsule::UnixSignal::{self, *};
-use failure::Fallible;
 use tracing::{info, Level};
 use tracing_subscriber::fmt;
 
@@ -31,7 +31,7 @@ fn on_signal(signal: UnixSignal) -> bool {
     }
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .finish();

--- a/examples/skeleton/Cargo.toml
+++ b/examples/skeleton/Cargo.toml
@@ -16,7 +16,7 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
-failure = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/examples/skeleton/main.rs
+++ b/examples/skeleton/main.rs
@@ -16,13 +16,13 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::config::load_config;
 use capsule::Runtime;
-use failure::Fallible;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::TRACE)
         .finish();

--- a/examples/syn-flood/Cargo.toml
+++ b/examples/syn-flood/Cargo.toml
@@ -16,8 +16,8 @@ path = "main.rs"
 doctest = false
 
 [dependencies]
+anyhow = "1.0"
 capsule = { version = "0.1", path = "../../core" }
-failure = "0.1"
 metrics-core = "0.5"
 metrics-observer-yaml = "0.1"
 tracing = "0.1"

--- a/examples/syn-flood/main.rs
+++ b/examples/syn-flood/main.rs
@@ -16,13 +16,13 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+use anyhow::Result;
 use capsule::batch::{Batch, Pipeline};
 use capsule::config::load_config;
 use capsule::metrics;
 use capsule::packets::ip::v4::Ipv4;
 use capsule::packets::{Ethernet, Packet, Tcp4};
 use capsule::{batch, Mbuf, PortQueue, Runtime};
-use failure::Fallible;
 use metrics_core::{Builder, Drain, Observe};
 use metrics_observer_yaml::YamlBuilder;
 use std::collections::HashMap;
@@ -73,7 +73,7 @@ fn print_stats() {
     println!("{}", observer.drain());
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::INFO)
         .finish();

--- a/macros/src/derive_packet.rs
+++ b/macros/src/derive_packet.rs
@@ -74,12 +74,12 @@ pub fn gen_icmpv6(input: syn::DeriveInput) -> TokenStream {
             }
 
             #[inline]
-            fn try_parse(envelope: Self::Envelope, _internal: Internal) -> ::failure::Fallible<Self> {
+            fn try_parse(envelope: Self::Envelope, _internal: Internal) -> ::anyhow::Result<Self> {
                 envelope.parse::<::capsule::packets::icmp::v6::Icmpv6<E>>()?.downcast::<#name<E>>()
             }
 
             #[inline]
-            fn try_push(mut envelope: Self::Envelope, internal: Internal) -> ::failure::Fallible<Self> {
+            fn try_push(mut envelope: Self::Envelope, internal: Internal) -> ::anyhow::Result<Self> {
                 use ::capsule::packets::icmp::v6::{Icmpv6, Icmpv6Header, Icmpv6Message};
                 use ::capsule::packets::ip::{IpPacket, ProtocolNumbers};
 
@@ -172,12 +172,12 @@ pub fn gen_icmpv4(input: syn::DeriveInput) -> TokenStream {
             }
 
             #[inline]
-            fn try_parse(envelope: Self::Envelope, _internal: ::capsule::packets::Internal) -> ::failure::Fallible<Self> {
+            fn try_parse(envelope: Self::Envelope, _internal: ::capsule::packets::Internal) -> ::anyhow::Result<Self> {
                 envelope.parse::<::capsule::packets::icmp::v4::Icmpv4>()?.downcast::<#name>()
             }
 
             #[inline]
-            fn try_push(mut envelope: Self::Envelope, internal: ::capsule::packets::Internal) -> ::failure::Fallible<Self> {
+            fn try_push(mut envelope: Self::Envelope, internal: ::capsule::packets::Internal) -> ::anyhow::Result<Self> {
                 use ::capsule::packets::icmp::v4::{Icmpv4, Icmpv4Header, Icmpv4Message};
                 use ::capsule::packets::ip::{IpPacket, ProtocolNumbers};
 


### PR DESCRIPTION
## Description

Fixes [RUSTSEC-2020-0036](https://rustsec.org/advisories/RUSTSEC-2020-0036.html).

There are a few options but seems like `anyhow` is the most active and it's a pretty easy drop in replacement for error propagation. The derive macro is replaced with `thiserror`. Together that covers all the ways we were using `failure` crate.

## Type of change

maintenance chore